### PR TITLE
Refactor `host-deployments.imports.yml`

### DIFF
--- a/requirements/pallets/github.com/PlanktoScope/pallet-standard/host-deployments.imports.yml
+++ b/requirements/pallets/github.com/PlanktoScope/pallet-standard/host-deployments.imports.yml
@@ -1,8 +1,12 @@
 modifiers:
-  - target: /deployments/host/docker.deploy.yml
-  - target: /deployments/host/machine-name.deploy.yml
-  - target: /deployments/host/sshd.deploy.yml
-  - target: /deployments/host/networking
+  - type: add
+    target: /deployments/host
+    only-matching-any:
+      - docker.deploy.yml
+      - machine-name.deploy.yml
+      - sshd.deploy.yml
+  - type: add
+    target: /deployments/host/networking
   - type: remove
     target: /deployments/host/networking
     only-matching-any:


### PR DESCRIPTION
This PR restructures the file imports declaration for package deployments imported from https://github.com/PlanktoScope/pallet-standard , to be clearer about what it's doing.