### PR TITLE
Add systemd service for Tailscale auth key initialization

### DIFF
--- a/deployments/host/tailscale-auth-key.deploy.yml
+++ b/deployments/host/tailscale-auth-key.deploy.yml
@@ -1,0 +1,2 @@
+package: /packages/core/host/tailscale-auth-key
+disabled: false

--- a/packages/core/host/tailscale-auth-key/forklift-package.yml
+++ b/packages/core/host/tailscale-auth-key/forklift-package.yml
@@ -1,0 +1,17 @@
+package:
+  description: Automatically sets the Tailscale client's auth key
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  license: Apache-2.0
+  sources:
+    # Auto-generation scripts (Apache-2.0):
+    - https://github.com/openUC2/pallet
+
+deployment:
+  provides:
+    file-exports:
+      - description: systemd service to set the Tailscale auth key during boot
+        target: overlays/usr/lib/systemd/system/tailscale-add-auth-key.service
+      - description: systemd service enablement for tailscale-add-auth-key.service
+        target: overlays/etc/systemd/system/multi-user.target.wants/tailscale-add-auth-key.service

--- a/packages/core/host/tailscale-auth-key/overlays/etc/systemd/system/multi-user.target.wants/tailscale-add-auth-key.service
+++ b/packages/core/host/tailscale-auth-key/overlays/etc/systemd/system/multi-user.target.wants/tailscale-add-auth-key.service
@@ -1,0 +1,1 @@
+../../../../usr/lib/systemd/system/tailscale-add-auth-key.service

--- a/packages/core/host/tailscale-auth-key/overlays/usr/lib/systemd/system/tailscale-add-auth-key.service
+++ b/packages/core/host/tailscale-auth-key/overlays/usr/lib/systemd/system/tailscale-add-auth-key.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Set the tailscale client's auth key from /run/tailscale-auth-key
+ConditionPathExists=/run/tailscale-auth-key
+Requires=tailscaled.service
+After=tailscaled.service
+
+[Service]
+Type=oneshot
+ExecStart=sh -c 'tailscale up --authkey "$(cat /run/tailscale-auth-key)"'
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This PR implements a prototype system for tailscale device provisioning as proposed in https://github.com/openUC2/imswitch-os/issues/7#issuecomment-2802516619 .

Note: this only works on base OS images with tailscale installed!