### PR TITLE
Add systemd service to move pre-loaded files from `/boot/init-root` to `/`

### DIFF
--- a/deployments/host/boot-init-root.deploy.yml
+++ b/deployments/host/boot-init-root.deploy.yml
@@ -1,0 +1,2 @@
+package: /packages/core/host/boot-init-root
+disabled: false

--- a/packages/core/host/boot-init-root/forklift-package.yml
+++ b/packages/core/host/boot-init-root/forklift-package.yml
@@ -1,0 +1,16 @@
+package:
+  description: System service to initialize the root fs from `/boot` during startup
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  license: Apache-2.0
+  sources:
+    - https://github.com/openUC2/pallet
+
+deployment:
+  provides:
+    file-exports:
+      - description: systemd service to move the contents of `/boot/init-root` during boot
+        target: overlays/usr/lib/systemd/system/boot-init-root.service
+      - description: systemd service enablement for boot-init-root.service
+        target: overlays/etc/systemd/system/multi-user.target.wants/boot-init-root.service

--- a/packages/core/host/boot-init-root/forklift-package.yml
+++ b/packages/core/host/boot-init-root/forklift-package.yml
@@ -10,7 +10,7 @@ package:
 deployment:
   provides:
     file-exports:
-      - description: systemd service to move the contents of `/boot/init-root` during boot
+      - description: systemd service to move the contents of `/boot/firmware/init-root` during boot
         target: overlays/usr/lib/systemd/system/boot-init-root.service
       - description: systemd service enablement for boot-init-root.service
         target: overlays/etc/systemd/system/multi-user.target.wants/boot-init-root.service

--- a/packages/core/host/boot-init-root/overlays/etc/systemd/system/multi-user.target.wants/boot-init-root.service
+++ b/packages/core/host/boot-init-root/overlays/etc/systemd/system/multi-user.target.wants/boot-init-root.service
@@ -1,0 +1,1 @@
+../../../../usr/lib/systemd/system/boot-init-root.service

--- a/packages/core/host/boot-init-root/overlays/usr/lib/systemd/system/boot-init-root.service
+++ b/packages/core/host/boot-init-root/overlays/usr/lib/systemd/system/boot-init-root.service
@@ -1,10 +1,11 @@
 [Unit]
-Description=Move files from `/boot/firmware/init-root` into the root filesystem
+Description=Move files from /boot/firmware/init-root into the root filesystem
 ConditionPathExistsGlob=/boot/firmware/init-root/*
 
 [Service]
 Type=oneshot
-ExecStart=sh -c 'mv /boot/firmware/init-root/* /'
+ExecStart=sh -c 'cp -r /boot/firmware/init-root/* /'
+ExecStartPost=sh -c 'rm -rf /boot/firmware/init-root/*'
 Restart=no
 
 [Install]

--- a/packages/core/host/boot-init-root/overlays/usr/lib/systemd/system/boot-init-root.service
+++ b/packages/core/host/boot-init-root/overlays/usr/lib/systemd/system/boot-init-root.service
@@ -1,10 +1,10 @@
 [Unit]
-Description=Move files from `/boot/init-root` into the root filesystem
-ConditionPathExistsGlob=/boot/init-root/*
+Description=Move files from `/boot/firmware/init-root` into the root filesystem
+ConditionPathExistsGlob=/boot/firmware/init-root/*
 
 [Service]
 Type=oneshot
-ExecStart=sh -c 'mv /boot/init-root/* /'
+ExecStart=sh -c 'mv /boot/firmware/init-root/* /'
 Restart=no
 
 [Install]

--- a/packages/core/host/boot-init-root/overlays/usr/lib/systemd/system/boot-init-root.service
+++ b/packages/core/host/boot-init-root/overlays/usr/lib/systemd/system/boot-init-root.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Move files from `/boot/init-root` into the root filesystem
+ConditionPathExistsGlob=/boot/init-root/*
+
+[Service]
+Type=oneshot
+ExecStart=sh -c 'mv /boot/init-root/* /'
+Restart=no
+
+[Install]
+WantedBy=multi-user.target

--- a/requirements/pallets/github.com/PlanktoScope/pallet-standard/forklift-version-lock.yml
+++ b/requirements/pallets/github.com/PlanktoScope/pallet-standard/forklift-version-lock.yml
@@ -1,4 +1,4 @@
 type: pseudoversion
 tag: v2024.0.0
-timestamp: "20250403153801"
-commit: 805ef86bbe05c7412c998562b6d2963083cb25af
+timestamp: "20250414231313"
+commit: 8fd23fded73b71d391d47a14ca79684cfcb6aeb7


### PR DESCRIPTION
This PR implements a prototype system for rootfs device-specific/deployment-specific config provisioning as proposed in https://github.com/openUC2/imswitch-os/issues/7#issuecomment-2795833570 .

Note: when the SD card is plugged into a separate computer for pre-loading device-specific /deployment-specific files, the `init-root` directory will appear at the top level of the boot partition. However, starting with Raspberry Pi OS 12 (bookworm), the `init-root` directory instead appears at `/boot/firmware/init-root` in the booted Raspberry Pi.
