### PR TITLE
Add Docker Compose apps for sysadmin browser apps

### DIFF
--- a/requirements/pallets/github.com/PlanktoScope/pallet-standard/app-deployments.imports.yml
+++ b/requirements/pallets/github.com/PlanktoScope/pallet-standard/app-deployments.imports.yml
@@ -3,3 +3,4 @@ modifiers:
     target: /deployments/apps
     only-matching-any:
       - filebrowser-root.deploy.yml
+      - dozzle.deploy.yml

--- a/requirements/pallets/github.com/PlanktoScope/pallet-standard/app-deployments.imports.yml
+++ b/requirements/pallets/github.com/PlanktoScope/pallet-standard/app-deployments.imports.yml
@@ -4,3 +4,4 @@ modifiers:
     only-matching-any:
       - filebrowser-root.deploy.yml
       - dozzle.deploy.yml
+      - cockpit.deploy.yml

--- a/requirements/pallets/github.com/PlanktoScope/pallet-standard/app-deployments.imports.yml
+++ b/requirements/pallets/github.com/PlanktoScope/pallet-standard/app-deployments.imports.yml
@@ -1,0 +1,5 @@
+modifiers:
+  - type: add
+    target: /deployments/apps
+    only-matching-any:
+      - filebrowser-root.deploy.yml

--- a/requirements/pallets/github.com/PlanktoScope/pallet-standard/infra-deployments.imports.yml
+++ b/requirements/pallets/github.com/PlanktoScope/pallet-standard/infra-deployments.imports.yml
@@ -1,0 +1,5 @@
+modifiers:
+  - type: add
+    target: /deployments/infra
+    only-matching-any:
+      - caddy-ingress.deploy.yml


### PR DESCRIPTION
This PR follows up on https://github.com/openUC2/imswitch-os/issues/7#issuecomment-2810927696 by adding a Docker Compose app to deploy https://github.com/filebrowser/filebrowser as a root filesystem browser which can be used from the web browser. The root filesystem browser can be accessed from port 80 at URL path `/admin/fs`, e.g. http://home.uc2/admin/fs .

This PR also adds a deployment for Dozzle which can be accessed from port 80 at URL path `/admin/dozzle`.

This PR also adds a way to access Cockpit from port 80 at URL path `/admin/cockpit`. You can also access it from port 9090 at URL path `/admin/cockpit` (note that now you will have to use that URL path if you try to access it from port 9090).

TODOs:

- [x] Fix Cockpit app deployment