### PR TITLE
Add systemd service to fix file perms for `.nmconnection` files

### DIFF
--- a/deployments/host/networking/networkmanager-fix-nmconnection-perms.deploy.yml
+++ b/deployments/host/networking/networkmanager-fix-nmconnection-perms.deploy.yml
@@ -1,0 +1,1 @@
+package: /packages/core/host/networking/networkmanager-fix-nmconnection-perms

--- a/packages/core/host/networking/networkmanager-fix-nmconnection-perms/forklift-package.yml
+++ b/packages/core/host/networking/networkmanager-fix-nmconnection-perms/forklift-package.yml
@@ -1,0 +1,16 @@
+package:
+  description: Automatically fixes incorrect file permission flags on NetworkManager connection files
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  license: Apache-2.0
+  sources:
+    - https://github.com/openUC2/pallet
+
+deployment:
+  provides:
+    file-exports:
+      - description: systemd service to set fix incorrect file permission flags for NetworkManager connection profiles during boot
+        target: overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
+      - description: systemd service enablement for networkmanager-fix-nmconnection-perms.service
+        target: overlays/etc/systemd/system/NetworkManager.service.wants/networkmanager-fix-nmconnection-perms.service

--- a/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/etc/systemd/system/NetworkManager.service.wants/networkmanager-fix-nmconnection-perms.service
+++ b/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/etc/systemd/system/NetworkManager.service.wants/networkmanager-fix-nmconnection-perms.service
@@ -1,0 +1,1 @@
+../../../../usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service

--- a/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
+++ b/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
@@ -6,14 +6,13 @@ Before=NetworkManager.service
 
 [Service]
 Type=oneshot
-ExecStart=sh -c '\
-  set -eu \
-  for file in /etc/NetworkManager/system-connections/*.nmconnection; do \
-    if [ -L "$file" ]; then \
-      continue \
-    fi \
-    chown root:root "$file" \
-    chmod 600 "$file" \
+ExecStart=bash -c -e '\
+  for file in /etc/NetworkManager/system-connections/*.nmconnection; do; \
+    if [ -L "$file" ]; then; \
+      continue; \
+    fi; \
+    chown root:root "$file"; \
+    chmod 600 "$file"; \
   done \
 '
 

--- a/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
+++ b/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
@@ -7,7 +7,7 @@ Before=NetworkManager.service
 [Service]
 Type=oneshot
 ExecStart=bash -c -e '\
-  for file in /etc/NetworkManager/system-connections/*.nmconnection; do; \
+  for file in /etc/NetworkManager/system-connections/*.nmconnection; do \
     if [ -L "$file" ]; then; \
       continue; \
     fi; \

--- a/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
+++ b/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Fix incorrect file permission flags for any NetworkManager connection profile files
+ConditionPathExists=/etc/NetworkManager/system-connections
+After=boot-init-root.service
+Before=NetworkManager.service
+
+[Service]
+Type=oneshot
+ExecStart=sh -c 'chown root:root /etc/NetworkManager/system-connections/*.nmconnection'
+ExecStart=sh -c 'chmod 600 /etc/NetworkManager/system-connections/*.nmconnection'
+
+[Install]
+WantedBy=NetworkManager.service

--- a/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
+++ b/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
@@ -6,8 +6,16 @@ Before=NetworkManager.service
 
 [Service]
 Type=oneshot
-ExecStart=sh -c 'chown root:root /etc/NetworkManager/system-connections/*.nmconnection'
-ExecStart=sh -c 'chmod 600 /etc/NetworkManager/system-connections/*.nmconnection'
+ExecStart=sh -c '\
+  set -eu \
+  for file in /etc/NetworkManager/system-connections/*.nmconnection; do \
+    if [ -L "$file" ]; then \
+      continue \
+    fi \
+    chown root:root "$file" \
+    chmod 600 "$file" \
+  done \
+'
 
 [Install]
 WantedBy=NetworkManager.service

--- a/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
+++ b/packages/core/host/networking/networkmanager-fix-nmconnection-perms/overlays/usr/lib/systemd/system/networkmanager-fix-nmconnection-perms.service
@@ -8,9 +8,7 @@ Before=NetworkManager.service
 Type=oneshot
 ExecStart=bash -c -e '\
   for file in /etc/NetworkManager/system-connections/*.nmconnection; do \
-    if [ -L "$file" ]; then; \
-      continue; \
-    fi; \
+    if [ -L "$file" ]; then continue; fi; \
     chown root:root "$file"; \
     chmod 600 "$file"; \
   done \


### PR DESCRIPTION
This PR implements the follow-up request made in https://github.com/openUC2/imswitch-os/issues/7#issuecomment-2874395402, to add a system service which (at boot) automatically fixes incorrect file ownership & permission flags for NetworkManager's `.nmconnection` files in `/etc/NetworkManager/system-connections`, so that the person copying such files into the boot partition's `init-root` directory won't have to fix `.nmconnection` file permissions/ownership themselves.