### PR TITLE
Add a proof-of-concept of a landing page

### DIFF
--- a/deployments/device-portal.deploy.yml
+++ b/deployments/device-portal.deploy.yml
@@ -1,0 +1,5 @@
+package: /packages/device-portal
+features:
+- frontend
+- deploy-rpi
+disabled: false

--- a/packages/device-portal/deploy-rpi.compose.yml
+++ b/packages/device-portal/deploy-rpi.compose.yml
@@ -1,0 +1,7 @@
+services:
+  server:
+    volumes:
+      - type: bind
+        source: /run/machine-name
+        target: /run/machine-name
+        read_only: true

--- a/packages/device-portal/deployment.compose.yml
+++ b/packages/device-portal/deployment.compose.yml
@@ -1,0 +1,7 @@
+services:
+  server:
+    image: ghcr.io/openuc2/device-portal:0.1.0@sha256:24a24915b417542c2585e25baa6b44f9e3e3bc14e0b72c076c323799fda41d53
+networks:
+  default:
+    name: none
+    external: true

--- a/packages/device-portal/dev-mock.compose.yml
+++ b/packages/device-portal/dev-mock.compose.yml
@@ -1,0 +1,4 @@
+services:
+  server:
+    environment:
+      - MACHINENAME_NAME=dev-machine

--- a/packages/device-portal/forklift-package.yml
+++ b/packages/device-portal/forklift-package.yml
@@ -1,0 +1,45 @@
+package:
+  description: Landing page for easy access to deployed browser applications
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  license: Apache-2.0
+  sources:
+    - https://github.com/openUC2/device-portal
+
+deployment:
+  compose-files:
+    - deployment.compose.yml
+
+features:
+  frontend:
+    description: Provides access to a browser landing page
+    compose-files:
+      - frontend.compose.yml
+    requires:
+      networks:
+        - description: Overlay network for Caddy to connect to upstream services
+          name: caddy-ingress
+      services:
+        - tags: [caddy-docker-proxy]
+          port: 80
+          protocol: http
+    provides:
+      services:
+        - description: Landing page for the PlanktoScope's network services
+          port: 80
+          protocol: http
+          paths:
+            - /
+            - /favicon.ico
+            - /app/*
+            - /static/*
+            - /fonts/*
+  deploy-rpi:
+    description: Integrates with Imswitch OS
+    compose-files:
+      - deploy-rpi.compose.yml
+  dev-mock:
+    description: Provides a fake machine name, to enable development & testing outside ImSwitch OS
+    compose-files:
+      - dev-mock.compose.yml

--- a/packages/device-portal/frontend.compose.yml
+++ b/packages/device-portal/frontend.compose.yml
@@ -1,0 +1,20 @@
+services:
+  server:
+    networks:
+      - caddy-ingress
+    labels:
+      caddy: :80
+      caddy.handle_0: /
+      caddy.handle_0.reverse_proxy: "{{upstreams 3000}}"
+      caddy.handle_1: /favicon.ico
+      caddy.handle_1.reverse_proxy: "{{upstreams 3000}}"
+      caddy.handle_2: /app/*
+      caddy.handle_2.reverse_proxy: "{{upstreams 3000}}"
+      caddy.handle_3: /static/*
+      caddy.handle_3.reverse_proxy: "{{upstreams 3000}}"
+      caddy.handle_4: /fonts/*
+      caddy.handle_4.reverse_proxy: "{{upstreams 3000}}"
+
+networks:
+  caddy-ingress:
+    external: true


### PR DESCRIPTION
Part of a resolution for https://github.com/openUC2/imswitch-os/issues/13 .

The landing page added by this PR is provided by https://github.com/openUC2/device-portal (a new repo created for this PR), which uses https://github.com/PlanktoScope/device-portal as starter code. This landing page doesn't actually provide any of the links specified in https://github.com/openUC2/imswitch-os/issues/13; that will be done in a future PR. This landing page is only a minimal proof-of-concept which strips down whatever was irrelevant from PlanktoScope/device-portal.