### PR TITLE
feat: add useful links to the landing page

### DIFF
--- a/packages/device-portal/deploy-rpi.compose.yml
+++ b/packages/device-portal/deploy-rpi.compose.yml
@@ -5,3 +5,7 @@ services:
         source: /run/machine-name
         target: /run/machine-name
         read_only: true
+      # - type: bind
+      #   source: /etc/device-portal/web/templates
+      #   target: /web/templates
+      #   read_only: true

--- a/packages/device-portal/deployment.compose.yml
+++ b/packages/device-portal/deployment.compose.yml
@@ -1,6 +1,13 @@
 services:
   server:
-    image: ghcr.io/openuc2/device-portal:0.1.0@sha256:24a24915b417542c2585e25baa6b44f9e3e3bc14e0b72c076c323799fda41d53
+    image: ghcr.io/openuc2/device-portal:0.1.1-alpha.0
+    environment:
+      - TEMPLATES_PATH=/web/templates
+    volumes:
+      - type: bind
+        source: ./templates
+        target: /web/templates
+        read_only: true
 networks:
   default:
     name: none

--- a/packages/device-portal/deployment.compose.yml
+++ b/packages/device-portal/deployment.compose.yml
@@ -1,6 +1,6 @@
 services:
   server:
-    image: ghcr.io/openuc2/device-portal:0.1.1-alpha.0
+    image: ghcr.io/openuc2/device-portal:0.1.1-alpha.1
     environment:
       - TEMPLATES_PATH=/web/templates
     volumes:

--- a/packages/device-portal/dev-mock.compose.yml
+++ b/packages/device-portal/dev-mock.compose.yml
@@ -2,3 +2,8 @@ services:
   server:
     environment:
       - MACHINENAME_NAME=dev-machine
+    # volumes:
+    #   - type: bind
+    #     source: $FORKLIFT_STAGED/etc/device-portal/web/templates
+    #     target: /web/templates
+    #     read_only: true

--- a/packages/device-portal/forklift-package.yml
+++ b/packages/device-portal/forklift-package.yml
@@ -5,7 +5,10 @@ package:
       email: lietk12@gmail.com
   license: Apache-2.0
   sources:
+    # Forklift-deployed software (MIT):
     - https://github.com/openUC2/device-portal
+    # Templates (Apache-2.0):
+    - https://github.com/openUC2/pallet
 
 deployment:
   compose-files:

--- a/packages/device-portal/templates/home/home.page.tmpl
+++ b/packages/device-portal/templates/home/home.page.tmpl
@@ -191,6 +191,7 @@
             An auto-generated report of the MAC addresses of all network interfaces in this machine,
             updated every few minutes
           </li>
+        </ul>
         <p>System recovery:</p>
         <ul>
           <li>

--- a/packages/device-portal/templates/home/home.page.tmpl
+++ b/packages/device-portal/templates/home/home.page.tmpl
@@ -1,0 +1,248 @@
+{{template "shared/base.layout.tmpl" .}}
+
+{{define "title" -}}
+  {{- $machineName := .Data.MachineName -}}
+  Machine {{$machineName}}
+{{- end}}
+{{define "description"}}Machine portal{{end}}
+
+{{define "content"}}
+  {{$hostname := .Data.Hostname}}
+  {{$port := .Data.Port}}
+  {{$machineName := .Data.MachineName}}
+
+  <main>
+    <section class="section content">
+      <div class="container">
+        <h1>Machine {{$machineName}}</h1>
+        <p>
+          Welcome! This is the home page for your machine with machine name
+          <code>{{$machineName}}</code>.
+        </p>
+        <p>
+          Below you can find a list of links to browser applications provided by your machine,
+          documentation for operating your machine,
+          and other information to help you use your machine.
+        </p>
+
+        {{if not (hasSuffix ".local" $hostname)}}
+          <article class="message is-warning">
+            <div class="message-body">
+              Note: you are using the hostname <code>{{$hostname}}</code>, which might not work
+              outside of direct connections to the machine through its Wi-Fi hotspot or through
+              an Ethernet cable. If/when you want to connect to the machine through a Wi-Fi
+              router or Ethernet router (for example because you have connected your machine to
+              the internet through an external Wi-Fi network, which disables the machine's
+              Wi-Fi hotspot under certain conditions), you may instead need to use
+              <a href="//openuc2-{{$machineName}}.local">openuc2-{{$machineName}}.local</a>
+              to access this machine (though
+              <a href="//openuc2.local">openuc2.local</a>
+              should also work if no other machine are connected to the router).
+            </div>
+          </article>
+        {{else if not (hasPrefix "openuc2-" $hostname)}}
+          <article class="message is-info">
+            <div class="message-body">
+              Note: you are using the hostname <code>{{$hostname}}</code>, which will be ambiguous
+              if/when you are potentially connected (either directly or indirectly) to multiple
+                machine. In such situations, you will instead need to use
+              <a href="//openuc2-{{$machineName}}.local">openuc2-{{$machineName}}.local</a>
+              to access this machine.
+            </div>
+          </article>
+        {{end}}
+
+        <h2>Browser applications</h2>
+        <ul>
+          <li>
+            <strong><a href="//{{$hostname}}:8001/imswitch/index.html" target="_blank">ImSwitch dashboard</a></strong>:
+            Provides the standard user interface to operate the microscope
+          </li>
+        </ul>
+
+        <h2>Need help?</h2>
+
+        <h3 class="is-size-5">Wrong machine?</h3>
+        <p>
+          This machine has machine name <code>{{$machineName}}</code>. If you're looking for a
+          different machine:
+        </p>
+        <ul>
+          <li>
+            You should use your web browser to open that machine's machine-specific URL
+            instead.
+            {{if hasSuffix ".uc2" $hostname}}
+              For example, the machine-specific URL for this machine is
+              <a href="//{{$machineName}}.uc2">
+                {{- /* make template ignore the line break */ -}}
+                {{$machineName}}.uc2
+                {{- /* make template ignore the line break */ -}}
+              </a>.
+              Alternatively,
+              <a href="//openuc2-{{$machineName}}.local">
+                {{- /* make template ignore the line break */ -}}
+                openuc2-{{$machineName}}.local
+                {{- /* make template ignore the line break */ -}}
+              </a>
+              might also work if your web browser supports mDNS.
+            {{else if hasSuffix ".local" $hostname}}
+              For example, the machine-specific URL for this machine is
+              <a href="//openuc2-{{$machineName}}.local">
+                {{- /* make template ignore the line break */ -}}
+                openuc2-{{$machineName}}.local
+                {{- /* make template ignore the line break */ -}}
+              </a>.
+              Alternatively,
+              <a href="//{{$machineName}}.uc2">
+                {{- /* make template ignore the line break */ -}}
+                {{$machineName}}.uc2
+                {{- /* make template ignore the line break */ -}}
+              </a>
+              might also work if you're connecting directly to your machine (i.e. to its
+              Ethernet port or to a Wi-Fi network created by your machine) and your web browser
+              isn't using Private DNS to look up domain names.
+            {{end}}
+          </li>
+          <li>
+            {{if hasSuffix ".uc2" $hostname}}
+              You're probably trying to connect directly to your machine (i.e. to its Ethernet
+              port or to a Wi-Fi network created by that machine). You
+            {{else}}
+              If you're trying to connect directly to a different machine (i.e. to its Ethernet
+              port or to a Wi-Fi network created by that machine), you
+            {{end}}
+            might need to change your
+            network configuration in order to connect to that machine's Wi-Fi network or
+            Ethernet port, and you might also need to disconnect from
+            <code>{{$machineName}}</code>'s Wi-Fi network or Ethernet port.
+          </li>
+        </ul>
+
+        <h3 class="is-size-5">Documentation</h3>
+        <p>Accessible offline:</p>
+        <ul>
+          <li>(no offline end-user documentation modules registered yet!)</li>
+        </ul>
+
+        <p>On the internet:</p>
+        <ul>
+          <li>
+            <strong><a href="https://openuc2.github.io/docs/ImSwitch/Quickstart" target="_blank">
+              Quickstart Guide
+              {{- /* make template ignore the line break */ -}}
+            </a></strong>:
+            A guide for getting started with the software on this machine
+          </li>
+          <li>
+            <strong><a href="https://openuc2.github.io/docs/ImSwitch/Advanced/" target="_blank">
+              ImSwitch Documentation
+              {{- /* make template ignore the line break */ -}}
+            </a></strong>:
+            Comprehensive guides for using Imswitch beyond the Quickstart Guide
+          </li>
+          <li>
+            <strong><a href="https://openuc2.github.io/docs/Investigator/FRAME/" target="_blank">
+              FRAME Microscope Manual
+              {{- /* make template ignore the line break */ -}}
+            </a></strong>:
+            A comprehensive operational manual for the FRAME microscope system
+          </li>
+        </ul>
+
+        <h3 class="is-size-5">Community</h3>
+        <ul>
+          <li>
+            <strong><a href="https://openuc2.com/" target="_blank">Official openUC2 website</a></strong>:
+            Information about the openUC2 optical toolbox
+          </li>
+          <li>
+            <strong><a href="https://openuc2.discourse.group/" target="_blank">Discourse group</a></strong>:
+            A forum for talking about openUC2 and getting help
+          </li>
+          <li>
+            <strong><a href="https://github.com/openUC2" target="_blank">GitHub organization</a></strong>:
+            openUC2's GitHub organization for development of the openUC2 optical toolbox
+          </li>
+        </ul>
+
+        <h2>For advanced users</h2>
+        <h3 class="is-size-5">Browser applications</h3>
+        <p>System administration and troubleshooting:</p>
+        <ul>
+          <li>
+            <strong><a href="/admin/cockpit/" target="_blank">Cockpit</a></strong>:
+            A general-purpose system administration dashboard for the computer embedded in this
+            machine
+          </li>
+          <li>
+            <strong><a href="/admin/fs/" target="_blank">System file manager</a></strong>:
+            A file browsing and management interface for the entire filesystem of the
+            computer embedded in this machine
+          </li>
+          <li>
+            <strong><a href="/admin/dozzle/" target="_blank">Dozzle</a></strong>:
+            A dashboard for monitoring and troubleshooting the apps deployed on this machine
+          </li>
+          <li>
+            <strong><a href="/admin/fs/files/run/mac-addresses.yml" target="_blank">
+              MAC address viewer
+              {{- /* make template ignore the line break */ -}}
+            </a></strong>:
+            An auto-generated report of the MAC addresses of all network interfaces in this machine,
+            updated every few minutes
+          </li>
+        <p>System recovery:</p>
+        <ul>
+          <li>
+            <strong><a href="//{{$hostname}}:9090/admin/cockpit/" target="_blank">
+              Cockpit (direct-access fallback)
+              {{- /* make template ignore the line break */ -}}
+            </a></strong>:
+            Fallback access to the Cockpit application, accessible even if the system's
+            service proxy stops working
+          </li>
+        </ul>
+
+        <h3 class="is-size-5">Network APIs</h3>
+        <ul>
+          <li>
+            <strong><a href="//{{$hostname}}:8001/api" target="_blank">ImSwitch API</a></strong>:
+            ImSwitch's HTTP API (useful for remote control)
+          </li>
+          <li>
+            <strong><a href="//{{$hostname}}:8001/docs" target="_blank">ImSwitch API docs</a></strong>:
+            Swagger docs for ImSwitch's HTTP API (also useful for testing API endpoints)
+          </li>
+          <li>
+            <strong><a href="//{{$hostname}}:8001/openapi.json" target="_blank">ImSwitch API spec</a></strong>:
+            OpenAPI specification for ImSwitch's HTTP API (useful for generating API clients)
+          </li>
+        </ul>
+
+        <h3 class="is-size-5">System infrastructure</h3>
+        <p>Networking:</p>
+        <ul>
+          <li>
+            <strong>SSH server</strong>:
+            Provides SSH access to this machine at <code>{{$hostname}}:22</code>
+          </li>
+          <li>
+            <strong>Service proxy</strong>:
+            A reverse-proxy to make browser applications and HTTP network APIs uniformly available
+            at different paths at <code>{{$hostname}}</code> on port 80
+          </li>
+          <li>
+            <strong>Forklift</strong>:
+            A software deployment and configuration management system for more robust software
+            updates even with extensive user customizations
+          </li>
+          <li>
+            <strong><a href="/" target="_blank">Device portal</a></strong>:
+            A landing page as a portal to the browser applications, network APIs, and system
+            infrastructure on this machine (this is what you're seeing right now)
+          </li>
+        </ul>
+      </div>
+    </section>
+  </main>
+{{end}}


### PR DESCRIPTION
This PR follows up on https://github.com/openUC2/pallet/pull/18 by adding links which were excluded from that PR. Links are specified in a `home.page.tmpl` file in this pallet, added by this PR. As a result, this PR resolves https://github.com/openUC2/imswitch-os/issues/13 .

Note: for this PR, the `home.page.tmpl` file is monolithic; a future PR will be needed if we want to have a modularly-built landing page where entries are provided by Forklift packages, so that disabling a Forklift package will automatically remove its entry from the landing page.

This work is tracked in https://www.notion.so/Allow-the-landing-page-to-load-template-files-from-the-filesystem-2754e612c78a80eea4bcfcff73ae815a?source=copy_link