### PR TITLE
Add an offline copy of the project docs

### DIFF
--- a/deployments/docs.deploy.yml
+++ b/deployments/docs.deploy.yml
@@ -1,0 +1,2 @@
+package: /packages/docs
+disabled: false

--- a/packages/device-portal/templates/home/home.page.tmpl
+++ b/packages/device-portal/templates/home/home.page.tmpl
@@ -127,7 +127,31 @@
         <h3 class="is-size-5">Documentation</h3>
         <p>Accessible offline:</p>
         <ul>
-          <li>(no offline end-user documentation modules registered yet!)</li>
+          <li>
+            <strong><a href="/docs/" target="_blank">openUC2 documentation</a></strong>:
+            Provides an offline copy of the official openUC2 project documentation
+          </li>
+          <li>
+            <strong><a href="/docs/ImSwitch/Quickstart" target="_blank">
+              Quickstart Guide
+              {{- /* make template ignore the line break */ -}}
+            </a></strong>:
+            A guide for getting started with the software on this machine
+          </li>
+          <li>
+            <strong><a href="/docs/ImSwitch/Advanced/" target="_blank">
+              ImSwitch Documentation
+              {{- /* make template ignore the line break */ -}}
+            </a></strong>:
+            Comprehensive guides for using Imswitch beyond the Quickstart Guide
+          </li>
+          <li>
+            <strong><a href="/docs/Investigator/FRAME/" target="_blank">
+              FRAME Microscope Manual
+              {{- /* make template ignore the line break */ -}}
+            </a></strong>:
+            A comprehensive operational manual for the FRAME microscope system
+          </li>
         </ul>
 
         <p>On the internet:</p>

--- a/packages/docs/deployment.compose.yml
+++ b/packages/docs/deployment.compose.yml
@@ -1,0 +1,13 @@
+services:
+  server:
+    image: ghcr.io/openuc2/project-docs:sha-f7c964b
+    volumes:
+      - server-data:/data
+      - server-config:/config
+networks:
+  default:
+    name: none
+    external: true
+volumes:
+  server-data: null
+  server-config: null

--- a/packages/docs/forklift-package.yml
+++ b/packages/docs/forklift-package.yml
@@ -1,0 +1,36 @@
+package:
+  description: Official documentation for the openUC2 project
+  # Note: this is the maintainer for the Forklift package, not for the documentation!
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  # Note: no license has been listed for this project
+  #license: 
+  sources:
+    - https://github.com/openUC2/openUC2.github.cio
+
+deployment:
+  compose-files:
+    - deployment.compose.yml
+
+features:
+  website:
+    description: Provides access to the website
+    compose-files:
+      - website.compose.yml
+    requires:
+      networks:
+        - description: Overlay network for Caddy to connect to upstream services
+          name: caddy-ingress
+      services:
+        - tags: [caddy-docker-proxy]
+          port: 80
+          protocol: http
+    provides:
+      services:
+        - description: openUC2 documentation site
+          port: 80
+          protocol: http
+          paths:
+            - /docs
+            - /docs/*

--- a/packages/docs/website.compose.yml
+++ b/packages/docs/website.compose.yml
@@ -1,0 +1,13 @@
+services:
+  server:
+    networks:
+      - caddy-ingress
+    labels:
+      caddy: :80
+      caddy.redir: /docs /docs/
+      caddy.handle_path: /docs/*
+      caddy.handle_path.reverse_proxy: "{{upstreams 80}}"
+
+networks:
+  caddy-ingress:
+    external: true


### PR DESCRIPTION
This PR follows up on https://github.com/openUC2/pallet/pull/21#issuecomment-3357561699 by deploying the Docker container image built by https://github.com/openUC2/openUC2.github.io/pull/15 in ImSwitch OS.

This work is tracked on Notion at https://www.notion.so/Serve-a-local-copy-of-the-docs-site-2774e612c78a80eba30bed5f566ca491?source=copy_link