### PR TITLE
Fix issue with pre-configuring Tailscale device auth key before the first boot

### DIFF
--- a/packages/core/host/tailscale-auth-key/overlays/usr/lib/systemd/system/tailscale-add-auth-key.service
+++ b/packages/core/host/tailscale-auth-key/overlays/usr/lib/systemd/system/tailscale-add-auth-key.service
@@ -1,12 +1,13 @@
 [Unit]
 Description=Set the tailscale client's auth key from /run/tailscale-auth-key
-ConditionPathExists=/run/tailscale-auth-key
+ConditionPathExists=/var/lib/tailscale-auth-key
 Requires=tailscaled.service
 After=tailscaled.service
 
 [Service]
 Type=oneshot
-ExecStart=sh -c 'tailscale up --authkey "$(cat /run/tailscale-auth-key)"'
+ExecStart=sh -c 'tailscale up --authkey "$(cat /var/lib/tailscale-auth-key)"'
+ExecStartPost=rm /var/lib/tailscale-auth-key
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This PR fixes a bug I discovered in testing my implementation of https://www.notion.so/DN-25-Customer-specific-OS-pre-configuration-2924e612c78a80b9b97cfffc199f3ae5?source=copy_link: The first boot of the RPi with a pre-configured OS image (including a Tailscale device auth key included in the init-root archive) doesn't go far enough to actually use the Tailscale device auth key in `/run`, which (by design) disappears on the next boot. So then the device auth key gets deleted before we can actually use it with Tailscale. To fix this bug, this PR changes the location of the device auth key from `/run` to `/var/lib` so that the device auth key file will remain in persistent storage on the SD card until it is loaded; after being loaded, the device auth key file will be deleted automatically.

note for @beniroquai : this is not a blocker for finalizing the image for Paul (i.e. this PR doesn't have to be merged before we send Paul an image). Before I merge this PR, the workaround for this issue is just to copy the init-root archive onto the boot partition [again,] after the RPi's first boot.