### PR TITLE
Add opt-in feature flags to disable Wi-Fi hotspot auto-creation

### DIFF
--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
@@ -81,6 +81,12 @@ features:
         - description: Auto-generated NetworkManager connection fragment file
           paths:
             - /run/overlays/generated/etc/NetworkManager/system-connections.d/wlan0-hotspot/40-generated-templated.nmconnection
+  wlan0-autoconnect-off:
+    description: Disable automatic creation of the Wi-Fi hotspot
+    provides:
+      file-exports:
+        - description: Drop-in NetworkManager connection fragment with autoconnect disablement
+          target: overlays/etc/NetworkManager/system-connections.d/wlan0-hotspot/21-connection-autoconnect-off.nmconnection
   wlan0-localization:
     description: Set Wi-Fi localization settings for maximum international compatibility
     provides:
@@ -162,6 +168,12 @@ features:
         - description: Auto-generated NetworkManager connection fragment file
           paths:
             - /run/overlays/generated/etc/NetworkManager/system-connections.d/wlan1-hotspot/40-generated-templated.nmconnection
+  wlan1-autoconnect-off:
+    description: Disable automatic creation of the Wi-Fi hotspot
+    provides:
+      file-exports:
+        - description: Drop-in NetworkManager connection fragment with autoconnect disablement
+          target: overlays/etc/NetworkManager/system-connections.d/wlan1-hotspot/21-connection-autoconnect-off.nmconnection
   wlan1-localization:
     description: Set Wi-Fi localization settings for maximum international compatibility
     provides:

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/overlays/etc/NetworkManager/system-connections.d/wlan0-hotspot/21-connection-autoconnect-off.nmconnection
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/overlays/etc/NetworkManager/system-connections.d/wlan0-hotspot/21-connection-autoconnect-off.nmconnection
@@ -1,0 +1,1 @@
+autoconnect=false

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/overlays/etc/NetworkManager/system-connections.d/wlan1-hotspot/21-connection-autoconnect-off.nmconnection
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/overlays/etc/NetworkManager/system-connections.d/wlan1-hotspot/21-connection-autoconnect-off.nmconnection
@@ -1,0 +1,1 @@
+autoconnect=false


### PR DESCRIPTION
As discussed in [DN 32](https://www.notion.so/DN-32-Automatic-Wi-Fi-mode-switching-behavior-in-FRAME-machines-2964e612c78a8093914dc0b7b73c7d3d?v=2854e612c78a807d88e7000c2f946422&source=copy_link#2964e612c78a80e69861d4e25c85b803), there are certain scenarios where we will want to prevent NetworkManager from automatically creating a Wi-Fi hotspot, e.g. if we have wlan0 configured to connect to an external network and wlan1 configured to always create a Wi-Fi hotspot, then we don't really need to make wlan0 automatically create a Wi-Fi hotspot if the external network is temporarily down.

This PR adds two feature flags (both disabled by default) which can be enabled to prevent NetworkManager from automatically bringing up Wi-Fi hotspots on wlan0 and wlan1, respectively.