### PR TITLE
Bump ImSwitch

### DIFF
--- a/deployments/imswitch.pkg/compose.yml
+++ b/deployments/imswitch.pkg/compose.yml
@@ -1,7 +1,7 @@
 services:
 
   imswitch-noqt:
-    image: ghcr.io/openuc2/imswitch-noqt:sha-39bdb26@sha256:3fda04dc977213a6dee52d13fb7c20db6bb5e0245c5c2f90bd759c082c429d93
+    image: ghcr.io/openuc2/imswitch-noqt:sha-c1383c0@sha256:b0abc0aea112fc13e76c45560b433af4091f3c083cd58601c4c8adc4d3503269
     privileged: true
     ports:
       - "8001:8001" # frontend, HTTP API, WebSockets API


### PR DESCRIPTION
This PR integrates https://github.com/openUC2/ImSwitch/pull/192 , and I guess also some changes which @beniroquai committed directly to the master branch of the ImSwitch between when https://github.com/openUC2/ImSwitch/pull/192 was created and when this PR gets merged (most notably https://github.com/openUC2/ImSwitch-ReactAPP/pull/104).

This work is tracked on Notion at https://www.notion.so/Remove-ImSwitch-NetworkManager-integration-2724e612c78a8060ad78e6375d241da7?source=copy_link .