### PR TITLE
Add boot configs to improve support for the HAT+ and RTC battery

### DIFF
--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -187,13 +187,13 @@ jobs:
       # Actions log outputs for setting up pinspawn-action for the first time from the logs for
       # the OS installation script
       - name: Install pinspawn-action dependencies
-        uses: ethanjli/pinspawn-action@v0.1.4
+        uses: ethanjli/pinspawn-action@v0.1.5
         with:
           image: ${{ steps.expand-image.outputs.destination }}
           run: echo "Done!"
 
       - name: Run OS setup scripts in an unbooted container
-        uses: ethanjli/pinspawn-action@v0.1.4
+        uses: ethanjli/pinspawn-action@v0.1.5
         with:
           image: ${{ steps.expand-image.outputs.destination }}
           user: ${{ env.SETUP_USER }}
@@ -216,7 +216,7 @@ jobs:
             echo "Done!"
 
       - name: Prepare for a headless first boot on bare metal
-        uses: ethanjli/pinspawn-action@v0.1.4
+        uses: ethanjli/pinspawn-action@v0.1.5
         env:
           DEFAULT_PASSWORD: youseetoo
           DEFAULT_KEYBOARD_LAYOUT: de

--- a/deployments/docs.deploy.yml
+++ b/deployments/docs.deploy.yml
@@ -1,4 +1,4 @@
 package: /deployments/docs.pkg
 features:
   - website
-disabled: false
+disabled: true

--- a/deployments/networking/networkmanager/base.pkg/overlays/usr/libexec/assemble-networkmanager-connection
+++ b/deployments/networking/networkmanager/base.pkg/overlays/usr/libexec/assemble-networkmanager-connection
@@ -4,4 +4,4 @@ connection="$1"
 
 mkdir -p /run/overlays/generated/etc/NetworkManager/system-connections
 cat "/etc/NetworkManager/system-connections.d/$connection/"* >"/run/overlays/generated/etc/NetworkManager/system-connections/$connection.nmconnection"
-sudo chmod 0600 "/run/overlays/generated/etc/NetworkManager/system-connections/$connection.nmconnection"
+chmod 0600 "/run/overlays/generated/etc/NetworkManager/system-connections/$connection.nmconnection"

--- a/os-build/cockpit/install.sh
+++ b/os-build/cockpit/install.sh
@@ -2,13 +2,22 @@
 # Cockpit enables system administration from a web browser.
 
 # Install cockpit
+# # Note: we need to adjust update-initramfs's behavior to make apt-get finish successfully; see
+# https://github.com/PlanktoScope/PlanktoScope/pull/596 and
+# https://github.com/RPi-Distro/repo/issues/382 for details.
+adjust_initramfs_scope=false
+if grep -q 'MODULES=dep' /etc/initramfs-tools/initramfs.conf; then
+  adjust_initramfs_scope=true
+  sudo sed -i 's~MODULES=dep~MODULES=most~' /etc/initramfs-tools/initramfs.conf
+fi
 sudo -E apt-get install -y --no-install-recommends -o Dpkg::Progress-Fancy=0 \
   cockpit cockpit-networkmanager cockpit-storaged
+if [ "$adjust_initramfs_scope" = true ]; then
+  sudo sed -i 's~MODULES=most~MODULES=dep~' /etc/initramfs-tools/initramfs.conf
+fi
 
 # install cockpit-navigator
 wget -O /tmp/cockpit-navigator.deb https://github.com/45Drives/cockpit-navigator/releases/download/v0.5.10/cockpit-navigator_0.5.10-1focal_all.deb
 ls
 sudo apt-get install -y /tmp/cockpit-navigator.deb
 rm /tmp/cockpit-navigator.deb
-
-echo "Installation complete. Access Cockpit at https://<IP-ADDRESS>:9090/"

--- a/os-build/platform-hardware/boot/firmware/config.txt.snippet
+++ b/os-build/platform-hardware/boot/firmware/config.txt.snippet
@@ -1,0 +1,6 @@
+
+# Allow the RPi to source more current to attached peripheral devices:
+usb_max_current_enable=1
+
+# Allow the RPi 5 to charge an attached RTC battery
+dtparam=rtc_bbat_vhcg=3000000

--- a/os-build/platform-hardware/config.sh
+++ b/os-build/platform-hardware/config.sh
@@ -4,6 +4,7 @@
 # Raspberry Pi 4 running Raspberry Pi OS 11 or newer.
 # Hopefully, in the future other platforms will also be supported - in which case alternative OS
 # build scripts will be needed for configuration.
+config_files_root="$(dirname "$(realpath "$BASH_SOURCE")")"
 
 # Note: in general, 0 represents "success/yes/selected", while 1 represents "failed/no/unselected",
 # but there is no consistent meaning. Partial documentation of raspi-commands is available at
@@ -29,3 +30,7 @@ sudo raspi-config nonint do_serial_cons 0
 
 # The following command disables legacy camera support so that we can use libcamera:
 sudo raspi-config nonint do_legacy 1
+
+# Add config.txt configuration for the openUC2 HAT+
+file="/boot/firmware/config.txt"
+sudo bash -c "cat \"$config_files_root$file.snippet\" >> \"$file\""

--- a/os-build/usb-storage/install.sh
+++ b/os-build/usb-storage/install.sh
@@ -1,8 +1,19 @@
 #!/bin/bash -eux
+# # Note: we need to adjust update-initramfs's behavior to make apt-get finish successfully; see
+# https://github.com/PlanktoScope/PlanktoScope/pull/596 and
+# https://github.com/RPi-Distro/repo/issues/382 for details.
+adjust_initramfs_scope=false
+if grep -q 'MODULES=dep' /etc/initramfs-tools/initramfs.conf; then
+  adjust_initramfs_scope=true
+  sudo sed -i 's~MODULES=dep~MODULES=most~' /etc/initramfs-tools/initramfs.conf
+fi
 sudo apt install -y -o DPkg::Lock::Timeout=60 -o Dpkg::Progress-Fancy=0 \
   udisks2 udisks2-lvm2 \
   exfat-fuse exfatprogs \
   ntfs-3g
+if [ "$adjust_initramfs_scope" = true ]; then
+  sudo sed -i 's~MODULES=most~MODULES=dep~' /etc/initramfs-tools/initramfs.conf
+fi
 
 sudo groupadd storage
 sudo usermod -aG storage "$USER"


### PR DESCRIPTION
This PR partially implements changes suggested in https://github.com/openUC2/TechnicalDocs-openUC2-FRAME/issues/161 (as part of openUC2 HAT+ enablement) and proposed in https://www.notion.so/DN-34-System-time-in-FRAME-machines-2a84e612c78a80569e37d71153c3fc4d?source=copy_link (for RTC support).

This PR was done together with @christiankuttke in a pair-programming/testing session.