### PR TITLE
Fix conflict between `tailscale funnel` and `forklift-apply.service`

### DIFF
--- a/deployments/networking/tailscale.deploy.yml
+++ b/deployments/networking/tailscale.deploy.yml
@@ -1,0 +1,4 @@
+package: /deployments/networking/tailscale.pkg
+features:
+  - tailscale-funnel-compatibility
+disabled: false

--- a/deployments/networking/tailscale.pkg/forklift-package.yml
+++ b/deployments/networking/tailscale.pkg/forklift-package.yml
@@ -1,0 +1,26 @@
+package:
+  description: Tailscale agent ambiently provided by the OS
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  license: BSD-3-Clause
+  sources:
+    - https://github.com/tailscale/tailscale
+
+host:
+  provides:
+    filesets:
+      - description: Sockets for tailscaled
+        paths:
+          - /run/tailscale/tailscaled.sock
+          - /var/run/tailscale/tailscaled.sock
+
+features:
+  tailscale-funnel-compatibility:
+    description: >
+      Unit override for tailscaled.service to add an ordering dependency for it to start after
+      forklift-apply.service
+    provides:
+      file-exports:
+        - description: Override of ordering dependencies for tailscaled.service
+          target: overlays/etc/systemd/system/tailscaled.service.d/after.conf

--- a/deployments/networking/tailscale.pkg/overlays/etc/systemd/system/tailscaled.service.d/after.conf
+++ b/deployments/networking/tailscale.pkg/overlays/etc/systemd/system/tailscaled.service.d/after.conf
@@ -1,0 +1,3 @@
+[Unit]
+# This adds a dependency on forklift-apply.service
+After=network-pre.target NetworkManager.service systemd-resolved.service forklift-apply.service


### PR DESCRIPTION
@beniroquai had encountered a problem where, upon enabling [Tailscale Funnel](https://tailscale.com/kb/1223/funnel) and rebooting the OS, `forklift-apply.service` would fail because the Caddy ingress proxy would fail to start. That failure occurs because Caddy tries to bind to port 443 on all IP addresses, but when Tailscale Funnel is enabled it binds to port 443 on a Tailscale-specific IP address. The fix for this is to start Tailscale Funnel _after_ Caddy, so that Caddy won't encounter that error. This PR implements that fix.

Note that this PR only fixes the conflict during boot; if the user wishes to manually restart `forklift-apply.service`, they'll need to first stop Tailscale Funnel.