### PR TITLE
Switch to RPi OS 13 (trixie) for base OS

### DIFF
--- a/.github/workflows/build-os-bookworm.yml
+++ b/.github/workflows/build-os-bookworm.yml
@@ -1,19 +1,6 @@
 ---
 name: build-os-bookworm
 on:
-  push:
-    branches:
-      - 'main'
-    tags:
-      - 'v*'
-    paths:
-      - '**'
-      - '!README.md'
-  pull_request:
-    paths:
-      - '**'
-      - '!README.md'
-  merge_group:
   workflow_dispatch:
     inputs:
       git-ref:

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -23,6 +23,12 @@ on:
 jobs:
   build:
     name: build
+    strategy:
+      fail-fast: false
+      matrix:
+        build_variant:
+          - ''
+          - 'dx'
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Raspberry Pi has released [RPi OS 13 (trixie)](https://www.raspberrypi.com/news/trixie-the-new-version-of-raspberry-pi-os/), and there aren't any major breaking/disruptive changes in the release notes as far as I can tell.

This PR stops automatically building OS images based on bookworm, and starts building dx images based on trixie (as a follow-up to #51). However, we can still manually trigger an OS image build based on bookworm via [workflow_dispatch](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow). Later, after enough testing of our OS on trixie, we can completely remove the bookworm CI build workflow in a future PR/commit.

This work is tracked on Notion at https://www.notion.so/Upgrade-OS-to-RPi-OS-13-trixie-29b4e612c78a8043a27fc27ed466ed04?source=copy_link