### PR TITLE
Support setting Wi-Fi country via boot-init-root

### DIFF
--- a/deployments/infra/forklift.pkg/overlays/etc/update-motd.d/50-forklift
+++ b/deployments/infra/forklift.pkg/overlays/etc/update-motd.d/50-forklift
@@ -119,9 +119,9 @@ fi
 if [ "$upgrade_query" == "" ]; then
   echo "Couldn't determine the upgrade query to check for upgrades!"
 else
-  echo "Update  source:        $upgrade_query"
+  echo "Update source:         $upgrade_query"
 fi
 if [ "$upgrade_available" != "" ]; then
   echo -e "${green_color}Upgrade available:     $upgrade_available$reset_color"
-  echo "To upgrade, run: forklift plt upgrade && sudo reboot"
+  echo "To update, run: forklift plt upgrade && sudo reboot"
 fi

--- a/deployments/provisioning/set-wifi-country.deploy.yml
+++ b/deployments/provisioning/set-wifi-country.deploy.yml
@@ -1,0 +1,2 @@
+package: /deployments/provisioning/set-wifi-country.pkg
+disabled: false

--- a/deployments/provisioning/set-wifi-country.pkg/forklift-package.yml
+++ b/deployments/provisioning/set-wifi-country.pkg/forklift-package.yml
@@ -1,0 +1,17 @@
+package:
+  description: Automatically sets the Wi-Fi country to match the kernel boot cmdline setting
+  maintainers:
+    - name: Ethan Li
+      email: lietk12@gmail.com
+  license: Apache-2.0
+  sources:
+    # Auto-generation scripts (Apache-2.0):
+    - https://github.com/openUC2/rpi-imswitch-os
+
+deployment:
+  provides:
+    file-exports:
+      - description: systemd service to set the kernal Wi-Fi country during boot
+        target: overlays/usr/lib/systemd/system/set-wifi-country.service
+      - description: systemd service enablement for set-wifi-country.service
+        target: overlays/etc/systemd/system/multi-user.target.wants/set-wifi-country.service

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/etc/systemd/system/multi-user.target.wants/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/etc/systemd/system/multi-user.target.wants/set-wifi-country.service
@@ -1,0 +1,1 @@
+../../../../usr/lib/systemd/system/set-wifi-country.service

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -5,7 +5,8 @@ After=boot-init-root.service
 
 [Service]
 Type=oneshot
-ExecStart=sh -c 'REGDOMAIN="$(sed -n \'s~.*cfg80211.ieee80211_regdom=\(\S*\).*~\1~p\' "$CMDLINE")" iw reg set "$REGDOMAIN"'
+ExecStart=sh -c 'iw reg set "$(sed -n \'s~.*cfg80211.ieee80211_regdom=\(\S*\).*~\1~p\' /boot/firmware/cmdline.txt)"'
+ExecStartPost=iw reg get
 RemainAfterExit=yes
 
 [Install]

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -6,11 +6,11 @@ After=boot-init-root.service
 [Service]
 Type=oneshot
 ExecStart=bash -c -e -u '\
-  if [ -f /var/lib/wifi-country ]; then \
+  if [ ! -f /var/lib/wifi-country ]; then \
     exit 0; \
   fi; \
   export WIFI_COUNTRY="$(sed \'s~#.*$~~g\' /var/lib/wifi-country | tr -d \'[:space:]\')"; \
-  if !grep -q "${WIFI_COUNTRY}[[:space:]]" /usr/share/zoneinfo/iso3166.tab; then \
+  if ! grep -q "${WIFI_COUNTRY}[[:space:]]" /usr/share/zoneinfo/iso3166.tab; then \
     echo "$WIFI_COUNTRY is not a valid ISO/IEC 3166-1 alpha2 code!" >2; \
     exit 1; \
   fi; \

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -5,7 +5,7 @@ After=boot-init-root.service
 
 [Service]
 Type=oneshot
-ExecStart=bash -c -e -u '\
+ExecStart=:bash -c -e -u '\
   if [ ! -f /var/lib/wifi-country ]; then \
     echo "No need to update /boot/firmware/cmdline.txt!"; \
     exit 0; \
@@ -23,7 +23,7 @@ ExecStart=bash -c -e -u '\
     /boot/firmware/cmdline.txt && \
   rm /var/lib/wifi-country \
 '
-ExecStart=bash -c -e -u '\
+ExecStart=:bash -c -e -u '\
   export WIFI_COUNTRY="$(sed -n \'s~.*cfg80211.ieee80211_regdom=\\(\\S*\\).*~\\1~p\' /boot/firmware/cmdline.txt)" && \
   echo "Setting Wi-Fi country to $WIFI_COUNTRY as specified in /boot/firmware/cmdline.txt..." && \
   iw reg set "$WIFI_COUNTRY" \

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -1,25 +1,24 @@
 [Unit]
-Description=Set the Wi-Fi regulatory domain from /var/lib/tailscale-auth-key
+Description=Set the Wi-Fi regulatory domain from /var/lib/wifi-country
 ConditionPathExists=/boot/firmware/cmdline.txt
 After=boot-init-root.service
 
 [Service]
 Type=oneshot
 ExecStart=bash -c -e -u '\
-  if [ ! -f /var/lib/wifi-country ]; then \
-    exit 0; \
-  fi; \
-  export WIFI_COUNTRY="$(sed \'s~#.*$~~g\' /var/lib/wifi-country | tr -d \'[:space:]\')"; \
-  if !grep -q "${WIFI_COUNTRY}[[:space:]]" /usr/share/zoneinfo/iso3166.tab; then \
-    echo "$WIFI_COUNTRY is not a valid ISO/IEC 3166-1 alpha2 code!" >2; \
-    exit 1; \
-  fi; \
-  echo "Setting Wi-Fi country to $WIFI_COUNTRY in /boot/firmware/cmdline.txt..."; \
-  sed -i \
-    -e "s~\\s*cfg80211.ieee80211_regdom=\\S*~~" \
-    -e "s~\\(.*\\)~\\1 cfg80211.ieee80211_regdom=$WIFI_COUNTRY~" \
-    /boot/firmware/cmdline.txt && \
-  rm /var/lib/wifi-country \
+  if [ -f /var/lib/wifi-country ]; then \
+    WIFI_COUNTRY="$(sed \'s~#.*$~~g\' /var/lib/wifi-country | tr -d \'[:space:]\')"; \
+    if ! grep -q "${WIFI_COUNTRY}[[:space:]]" /usr/share/zoneinfo/iso3166.tab; then \
+      echo "$WIFI_COUNTRY is not a valid ISO/IEC 3166-1 alpha2 code!" >2; \
+      exit 1; \
+    fi; \
+    echo "Setting Wi-Fi country to $WIFI_COUNTRY in /boot/firmware/cmdline.txt..."; \
+    sed -i \
+      -e "s~\\s*cfg80211.ieee80211_regdom=\\S*~~" \
+      -e "s~\\(.*\\)~\\1 cfg80211.ieee80211_regdom=$WIFI_COUNTRY~" \
+      /boot/firmware/cmdline.txt && \
+    rm /var/lib/wifi-country; \
+  fi \
 '
 ExecStart=bash -c -e -u '\
   WIFI_COUNTRY="$(sed -n \'s~.*cfg80211.ieee80211_regdom=\\(\\S*\\).*~\\1~p\' /boot/firmware/cmdline.txt)" && \

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -5,7 +5,11 @@ After=boot-init-root.service
 
 [Service]
 Type=oneshot
-ExecStart=sh -c 'iw reg set "$(sed -n \'s~.*cfg80211.ieee80211_regdom=\\(\\S*\\).*~\\1~p\' /boot/firmware/cmdline.txt)"'
+ExecStart=sh -c '\
+  WIFI_COUNTRY="$(sed -n \'s~.*cfg80211.ieee80211_regdom=\\(\\S*\\).*~\\1~p\' /boot/firmware/cmdline.txt)" && \
+  echo "Setting Wi-Fi country to $WIFI_COUNTRY..." && \
+  iw reg set "$WIFI_COUNTRY" \
+'
 ExecStartPost=iw reg get
 RemainAfterExit=yes
 

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -5,14 +5,14 @@ After=boot-init-root.service
 
 [Service]
 Type=oneshot
-ExecStart=bash -c -e '\
+ExecStart=bash -c -e -u '\
   if [ ! -f /var/lib/wifi-country ]; then \
-    return 0; \
+    exit 0; \
   fi; \
-  WIFI_COUNTRY="$(sed \'s~#.*$~~g\' /var/lib/wifi-country | tr -d \'[:space:]\')"; \
+  export WIFI_COUNTRY="$(sed \'s~#.*$~~g\' /var/lib/wifi-country | tr -d \'[:space:]\')"; \
   if !grep -q "${WIFI_COUNTRY}[[:space:]]" /usr/share/zoneinfo/iso3166.tab; then \
     echo "$WIFI_COUNTRY is not a valid ISO/IEC 3166-1 alpha2 code!" >2; \
-    return 1; \
+    exit 1; \
   fi; \
   echo "Setting Wi-Fi country to $WIFI_COUNTRY in /boot/firmware/cmdline.txt..."; \
   sed -i \
@@ -21,7 +21,7 @@ ExecStart=bash -c -e '\
     /boot/firmware/cmdline.txt && \
   rm /var/lib/wifi-country \
 '
-ExecStart=bash -c -e '\
+ExecStart=bash -c -e -u '\
   WIFI_COUNTRY="$(sed -n \'s~.*cfg80211.ieee80211_regdom=\\(\\S*\\).*~\\1~p\' /boot/firmware/cmdline.txt)" && \
   echo "Setting Wi-Fi country to $WIFI_COUNTRY as specified in /boot/firmware/cmdline.txt..." && \
   iw reg set "$WIFI_COUNTRY" \

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Set the tailscale client's auth key from /run/tailscale-auth-key
+ConditionPathExists=/boot/firmware/cmdline.txt
+After=boot-init-root.service
+
+[Service]
+Type=oneshot
+ExecStart=sh -c 'REGDOMAIN="$(sed -n \'s~.*cfg80211.ieee80211_regdom=\(\S*\).*~\1~p\' "$CMDLINE")" iw reg set "$REGDOMAIN"'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -1,13 +1,29 @@
 [Unit]
-Description=Set the tailscale client's auth key from /run/tailscale-auth-key
+Description=Set the Wi-Fi regulatory domain from /var/lib/tailscale-auth-key
 ConditionPathExists=/boot/firmware/cmdline.txt
 After=boot-init-root.service
 
 [Service]
 Type=oneshot
-ExecStart=sh -c '\
+ExecStart=bash -c -e '\
+  if [ ! -f /var/lib/wifi-country ]; then \
+    return 0; \
+  fi; \
+  WIFI_COUNTRY="$(sed \'s~#.*$~~g\' /var/lib/wifi-country | tr -d \'[:space:]\')"; \
+  if !grep -q "${WIFI_COUNTRY}[[:space:]]" /usr/share/zoneinfo/iso3166.tab; then \
+    echo "$WIFI_COUNTRY is not a valid ISO/IEC 3166-1 alpha2 code!" >2; \
+    return 1; \
+  fi; \
+  echo "Setting Wi-Fi country to $WIFI_COUNTRY in /boot/firmware/cmdline.txt..."; \
+  sed -i \
+    -e "s~\\s*cfg80211.ieee80211_regdom=\\S*~~" \
+    -e "s~\\(.*\\)~\\1 cfg80211.ieee80211_regdom=$WIFI_COUNTRY~" \
+    /boot/firmware/cmdline.txt && \
+  rm /var/lib/wifi-country
+'
+ExecStart=bash -c -e '\
   WIFI_COUNTRY="$(sed -n \'s~.*cfg80211.ieee80211_regdom=\\(\\S*\\).*~\\1~p\' /boot/firmware/cmdline.txt)" && \
-  echo "Setting Wi-Fi country to $WIFI_COUNTRY..." && \
+  echo "Setting Wi-Fi country to $WIFI_COUNTRY as specified in /boot/firmware/cmdline.txt..." && \
   iw reg set "$WIFI_COUNTRY" \
 '
 ExecStartPost=iw reg get

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -7,21 +7,22 @@ After=boot-init-root.service
 Type=oneshot
 ExecStart=bash -c -e -u '\
   if [ -f /var/lib/wifi-country ]; then \
-    WIFI_COUNTRY="$(sed \'s~#.*$~~g\' /var/lib/wifi-country | tr -d \'[:space:]\')"; \
-    if ! grep -q "${WIFI_COUNTRY}[[:space:]]" /usr/share/zoneinfo/iso3166.tab; then \
-      echo "$WIFI_COUNTRY is not a valid ISO/IEC 3166-1 alpha2 code!" >2; \
-      exit 1; \
-    fi; \
-    echo "Setting Wi-Fi country to $WIFI_COUNTRY in /boot/firmware/cmdline.txt..."; \
-    sed -i \
-      -e "s~\\s*cfg80211.ieee80211_regdom=\\S*~~" \
-      -e "s~\\(.*\\)~\\1 cfg80211.ieee80211_regdom=$WIFI_COUNTRY~" \
-      /boot/firmware/cmdline.txt && \
-    rm /var/lib/wifi-country; \
-  fi \
+    exit 0; \
+  fi; \
+  export WIFI_COUNTRY="$(sed \'s~#.*$~~g\' /var/lib/wifi-country | tr -d \'[:space:]\')"; \
+  if !grep -q "${WIFI_COUNTRY}[[:space:]]" /usr/share/zoneinfo/iso3166.tab; then \
+    echo "$WIFI_COUNTRY is not a valid ISO/IEC 3166-1 alpha2 code!" >2; \
+    exit 1; \
+  fi; \
+  echo "Setting Wi-Fi country to $WIFI_COUNTRY in /boot/firmware/cmdline.txt..."; \
+  sed -i \
+    -e "s~\\s*cfg80211.ieee80211_regdom=\\S*~~" \
+    -e "s~\\(.*\\)~\\1 cfg80211.ieee80211_regdom=$WIFI_COUNTRY~" \
+    /boot/firmware/cmdline.txt && \
+  rm /var/lib/wifi-country \
 '
 ExecStart=bash -c -e -u '\
-  WIFI_COUNTRY="$(sed -n \'s~.*cfg80211.ieee80211_regdom=\\(\\S*\\).*~\\1~p\' /boot/firmware/cmdline.txt)" && \
+  export WIFI_COUNTRY="$(sed -n \'s~.*cfg80211.ieee80211_regdom=\\(\\S*\\).*~\\1~p\' /boot/firmware/cmdline.txt)" && \
   echo "Setting Wi-Fi country to $WIFI_COUNTRY as specified in /boot/firmware/cmdline.txt..." && \
   iw reg set "$WIFI_COUNTRY" \
 '

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -5,7 +5,7 @@ After=boot-init-root.service
 
 [Service]
 Type=oneshot
-ExecStart=sh -c 'iw reg set "$(sed -n \'s~.*cfg80211.ieee80211_regdom=\(\S*\).*~\1~p\' /boot/firmware/cmdline.txt)"'
+ExecStart=sh -c 'iw reg set "$(sed -n \'s~.*cfg80211.ieee80211_regdom=\\(\\S*\\).*~\\1~p\' /boot/firmware/cmdline.txt)"'
 ExecStartPost=iw reg get
 RemainAfterExit=yes
 

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -7,7 +7,9 @@ After=boot-init-root.service
 Type=oneshot
 ExecStart=bash -c -e -u '\
   if [ ! -f /var/lib/wifi-country ]; then \
+    echo "No need to update /boot/firmware/cmdline.txt!"; \
     exit 0; \
+    echo "uh-oh!"; \
   fi; \
   export WIFI_COUNTRY="$(sed \'s~#.*$~~g\' /var/lib/wifi-country | tr -d \'[:space:]\')"; \
   if ! grep -q "${WIFI_COUNTRY}[[:space:]]" /usr/share/zoneinfo/iso3166.tab; then \

--- a/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
+++ b/deployments/provisioning/set-wifi-country.pkg/overlays/usr/lib/systemd/system/set-wifi-country.service
@@ -19,7 +19,7 @@ ExecStart=bash -c -e '\
     -e "s~\\s*cfg80211.ieee80211_regdom=\\S*~~" \
     -e "s~\\(.*\\)~\\1 cfg80211.ieee80211_regdom=$WIFI_COUNTRY~" \
     /boot/firmware/cmdline.txt && \
-  rm /var/lib/wifi-country
+  rm /var/lib/wifi-country \
 '
 ExecStart=bash -c -e '\
   WIFI_COUNTRY="$(sed -n \'s~.*cfg80211.ieee80211_regdom=\\(\\S*\\).*~\\1~p\' /boot/firmware/cmdline.txt)" && \

--- a/deployments/provisioning/tailscale-auth-key.pkg/overlays/usr/lib/systemd/system/tailscale-add-auth-key.service
+++ b/deployments/provisioning/tailscale-auth-key.pkg/overlays/usr/lib/systemd/system/tailscale-add-auth-key.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Set the tailscale client's auth key from /run/tailscale-auth-key
+Description=Set the tailscale client's auth key from /var/lib/tailscale-auth-key
 ConditionPathExists=/var/lib/tailscale-auth-key
 Requires=tailscaled.service
 After=tailscaled.service


### PR DESCRIPTION
The Wi-Fi country is typically set before the kernel boots by editing the `cmdline.txt` file in the boot partition. However, the boot-init-root mechanism runs after the kernel boots. This PR adds a systemd service to set the Wi-Fi country after boot-init-root, so that the RPi doesn't have to be rebooted before any boot-init-root-applied change to the Wi-Fi country is actually realized. The setting is persisted in the `cmdline.txt` file.

Because it's not necessarily a good idea to fully overwrite `cmdline.txt` (since it also records the UUID of the root partition which varies between SD cards), this PR's new systemd service supports editing the Wi-Fi country of the `cmdline.txt` file via a file named `/var/lib/wifi-country` (whose contents should just be the desired Wi-Fi country).

This work is tracked on Notion at https://www.notion.so/Set-Wi-Fi-country-for-customer-2f74e612c78a8000b4e8df7db4513884?source=copy_link