### PR TITLE
Save snapshots of `/boot` and `/etc` for factory-reset mechanisms

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: build(ci)
+    groups:
+      ci:
+        patterns:
+          - '*'

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -248,6 +248,18 @@ jobs:
             # https://forums.raspberrypi.com/viewtopic.php?p=2032694#p2032694
             systemctl enable getty@tty1
 
+      - name: Freeze snapshots for factory reset
+        uses: ethanjli/pinspawn-action@v0.1.5
+        with:
+          image: ${{ steps.expand-image.outputs.destination }}
+          args: >-
+            --bind "$(pwd)":/run/pallet
+            --machine=raspberrypi
+          run: |
+            echo "Freezing snapshots for factory reset..."
+            /run/pallet/os-build/freeze.sh
+            echo "Done!"
+
       # UPLOAD OS IMAGE
 
       # TODO: save this to a file in the SD card image

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -303,10 +303,11 @@ jobs:
           compress-parallel: true
 
       - name: Upload image to Job Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.OUTPUT_IMAGE_NAME }}
           path: ${{ env.OUTPUT_IMAGE_NAME }}.img.xz
+          archive: false
           if-no-files-found: error
           retention-days: 0
           compression-level: 0

--- a/os-build/freeze.sh
+++ b/os-build/freeze.sh
@@ -1,0 +1,8 @@
+#!/bin/bash -eux
+# Freeze saves snapshots of `/boot` and `/etc` into `/usr/share/factory` to facilitate factory-reset
+# functionality.
+# This script needs to be run with root permissions.
+
+mkdir -p /usr/share/factory
+cp -r /boot /usr/share/factory/
+cp -r /etc /usr/share/factory/


### PR DESCRIPTION
Currently, `/boot` can only be modified with in-place edits. This PR saves a copy of the initial state of `/boot` to `/usr/share/factory/boot` to facilitate future comparison between the current contents of `/boot` and the initial state of `/boot` when the OS image was built. This enables factory-reset of `/boot`, and it could also be useful for future Forklift-based management of the contents of `/boot`.

This PR also saves the initial state of `/etc` to `/usr/share/factory/etc` so that any edits made in `/etc` when the OS is not booted (e.g. any edits made directly to the SD card from another computer) can be checked in a booted system by comparing `/sysroot/etc` to `/usr/share/factory/etc`. But this is only meant as a simple way to support factory-reset for such edits, not as a security mechanism to defend against malicious attackers: an attacker could duplicate their edits of `/etc` to `/usr/share/factory/etc` in a filesystem at rest, which would prevent their changes to `/etc` from being detected.