### PR TITLE
Fix regression in device-admin permissions

### DIFF
--- a/deployments/admin/device-admin.pkg/forklift-package.yml
+++ b/deployments/admin/device-admin.pkg/forklift-package.yml
@@ -10,6 +10,16 @@ package:
 deployment:
   compose-files:
     - deployment.compose.yml
+  provides:
+    file-exports:
+      - description: polkit rules for using NetworkManager's D-Bus API as the pi user
+        target: overlays/usr/share/polkit-1/rules.d/20-networkmanager.rules
+      - description: polkit rules for using UDisks2's D-Bus API as the pi user
+        target: overlays/usr/share/polkit-1/rules.d/20-udisks2.rules
+      - description: systemd template service for using tailscale's API as the specified non-root user
+        target: overlays/usr/lib/systemd/system/tailscale-set-operator@.service
+      - description: systemd service enablement for using tailscale's API as pi
+        target: overlays/etc/systemd/system/multi-user.target.wants/tailscale-set-operator@pi.service
 
 features:
   frontend:


### PR DESCRIPTION
This PR reverts a regression in #173 where some PolicyKit rules were accidentally deleted.