### PR TITLE
Temporarily allow untrusted access to all apps by default

### DIFF
--- a/deployments/infra/caddy-ingress-untrusted.deploy.yml
+++ b/deployments/infra/caddy-ingress-untrusted.deploy.yml
@@ -2,5 +2,5 @@ package: /deployments/infra/caddy-ingress-untrusted.pkg
 features:
   - firewall-allow-direct
   - firewall-allow-public
-  - firewall-forward-http-public
+  # - firewall-forward-http-public
 disabled: false

--- a/deployments/infra/caddy-ingress.deploy.yml
+++ b/deployments/infra/caddy-ingress.deploy.yml
@@ -1,4 +1,5 @@
 package: /deployments/infra/caddy-ingress.pkg
 features:
   - firewall-allow-direct
+  - firewall-allow-public
 disabled: false


### PR DESCRIPTION
This PR implements the change requested by @beniroquai in openUC2's Zulip (at [#teams/software > os-rpi @ 💬](https://chat.openuc2.com/#narrow/channel/4-teams.2Fsoftware/topic/os-rpi/near/724)) to loosen the firewall's default security configuration, by allowing access to the administrative apps from all users on untrusted Local Area Networks by default, for more convenient access to the RPi machines at openUC2's office.