### PR TITLE
Upload built OS images to Google Drive from Git tag pushes

### DIFF
--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -53,14 +53,13 @@ jobs:
       - name: Download built OS image
         uses: actions/download-artifact@v5
         with:
-          name: ${{ needs.build.outputs.image_name }}
+          name: ${{ needs.build.outputs.image_name }}.img.xz
           path: ${{ needs.build.outputs.image_name }}.img.xz
           github-token: ${{ github.token }}
 
       - name: Upload image to Google Drive
-        uses: adityak74/google-drive-upload-git-action@v0.3
+        uses: willo32/google-drive-upload-action@v1.1.0
         with:
-          filename: ${{ env.OUTPUT_IMAGE_NAME }}.img.xz
-          folderId: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}
+          target: ${{ env.OUTPUT_IMAGE_NAME }}.img.xz
+          parent_folder_id: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}
           credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}
-          overwrite: true

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -53,13 +53,12 @@ jobs:
       - name: Download built OS image
         uses: actions/download-artifact@v5
         with:
-          name: ${{ needs.build.outputs.image_name }}.img.xz
+          artifact-ids: ${{ needs.build.outputs.artifact_id }}.img.xz
           path: ${{ needs.build.outputs.image_name }}.img.xz
-          github-token: ${{ github.token }}
 
       - name: Upload image to Google Drive
         uses: willo32/google-drive-upload-action@v1.1.0
         with:
-          target: ${{ env.OUTPUT_IMAGE_NAME }}.img.xz
+          target: ${{ needs.build.outputs.image_name }}.img.xz
           parent_folder_id: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}
           credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -44,8 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-    # TODO: change this to "push tag" only
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push tag' }}
+    if: ${{ github.event_name == 'push tag' }}
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           artifact-ids: ${{ needs.build.outputs.artifact_id }}.img.xz
           path: ${{ needs.build.outputs.image_name }}.img.xz
+          github-token: ${{ github.token }}
 
       - name: Upload image to Google Drive
         uses: willo32/google-drive-upload-action@v1.1.0

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -54,7 +54,6 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           artifact-ids: ${{ needs.build.outputs.artifact_id }}.img.xz
-          path: ${{ needs.build.outputs.image_name }}.img.xz
           github-token: ${{ github.token }}
 
       - name: Upload image to Google Drive

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -58,8 +58,9 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Upload image to Google Drive
-        uses: codetheweb/upload-to-drive@v1.3.0
+        uses: Jumbo810/Upload_Github_Artifacts_TO_GDrive@v2.3.3
         with:
           target: ${{ needs.build.outputs.image_name }}.img.xz
-          folder: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}
+          parent_folder_id: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}
           credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}
+          replace_mode: update_in_place

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -51,7 +51,7 @@ jobs:
       actions: read
     steps:
       - name: Download built OS image
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           artifact-ids: ${{ needs.build.outputs.artifact_id }}.img.xz
           path: ${{ needs.build.outputs.image_name }}.img.xz

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -58,7 +58,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Upload image to Google Drive
-        uses: codetheweb/upload-to-google-drive-forked@v1.3.0
+        uses: codetheweb/upload-to-drive@v1.3.0
         with:
           target: ${{ needs.build.outputs.image_name }}.img.xz
           folder: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -58,7 +58,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Upload image to Google Drive
-        uses: codetheweb@v1.3.0
+        uses: codetheweb/upload-to-google-drive-forked@v1.3.0
         with:
           target: ${{ needs.build.outputs.image_name }}.img.xz
           folder: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -38,3 +38,29 @@ jobs:
       base_release_date: 2025-11-24
       base_file_release_date: 2025-11-24
       arch: arm64
+
+  upload:
+    name: Upload image (Google Drive)
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    # TODO: change this to "push tag" only
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'push tag' }}
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Download built OS image
+        uses: actions/download-artifact@v5
+        with:
+          name: ${{ needs.build.outputs.image_name }}
+          path: ${{ needs.build.outputs.image_name }}.img.xz
+          github-token: ${{ github.token }}
+
+      - name: Upload image to Google Drive
+        uses: adityak74/google-drive-upload-git-action@v0.3
+        with:
+          filename: ${{ env.OUTPUT_IMAGE_NAME }}.img.xz
+          folderId: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}
+          credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}
+          overwrite: true

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -58,7 +58,7 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Upload image to Google Drive
-        uses: Jodebu/upload-to-drive@v1.1.1
+        uses: codetheweb@v1.3.0
         with:
           target: ${{ needs.build.outputs.image_name }}.img.xz
           folder: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -58,8 +58,8 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Upload image to Google Drive
-        uses: willo32/google-drive-upload-action@v1.1.0
+        uses: Jodebu/upload-to-drive@v1.1.1
         with:
           target: ${{ needs.build.outputs.image_name }}.img.xz
-          parent_folder_id: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}
+          folder: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}
           credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -34,6 +34,9 @@ on:
       image_name:
         description: 'Name of the built OS image'
         value: ${{ jobs.build-os-image.outputs.image_name }}
+      artifact_id:
+        description: 'Artifact ID of the GitHub Artifacts upload of the built OS image'
+        value: ${{ jobs.build-os-image.outputs.artifact_id }}
 
 jobs:
   build-os-image:
@@ -43,6 +46,7 @@ jobs:
       SETUP_USER: pi
     outputs:
       image_name: ${{ steps.output-image.outputs.name }}
+      artifact_id: ${{ steps.upload-artifact.outputs.artifact-id }}
     permissions:
       contents: read
       packages: write
@@ -316,9 +320,9 @@ jobs:
           compress-parallel: true
 
       - name: Upload image to Job Artifacts
+        id: upload-artifact
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ env.OUTPUT_IMAGE_NAME }}
           path: ${{ env.OUTPUT_IMAGE_NAME }}.img.xz
           archive: false
           if-no-files-found: error

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -30,6 +30,10 @@ on:
         description: 'The CPU architecture of the OS (armhf, arm64)'
         required: true
         type: string
+    outputs:
+      image_name:
+        description: 'Name of the built OS image'
+        value: ${{ jobs.build-os-image.outputs.image_name }}
 
 jobs:
   build-os-image:
@@ -37,6 +41,8 @@ jobs:
     runs-on: ubuntu-24.04-arm
     env:
       SETUP_USER: pi
+    outputs:
+      image_name: ${{ steps.output-image.outputs.name }}
     permissions:
       contents: read
       packages: write
@@ -267,10 +273,11 @@ jobs:
 
       # UPLOAD OS IMAGE
 
-      # TODO: save this to a file in the SD card image
+      # TODO: save this to a "os-build" file in the OS image
       # TODO: use forklift to determine the version/pseudoversion string; if it's a PR, append that
       # only as a semver build tag
       - name: Determine output image name
+        id: output-image
         env:
           TAG_PREFIX: "v"
         run: |
@@ -296,6 +303,7 @@ jobs:
           fi
           output_name="$output_name-$version"
           echo "OUTPUT_IMAGE_NAME=$output_name" >> $GITHUB_ENV
+          echo "name=$output_name" >> $GITHUB_OUTPUT
 
       - name: Shrink the OS image
         uses: ethanjli/pishrink-action@v0.1.4


### PR DESCRIPTION
This PR makes the CI workflow for building OS images also upload those OS images to Google Drive for simpler/faster/easier sharing and auto-downloading.

This work is tracked on Notion at https://app.notion.com/p/Automatically-upload-rpi-imswitch-os-OS-images-to-Google-Drive-from-Github-Actions-2fe4e612c78a80d08db1e9fb2043df29?source=copy_link .