### PR TITLE
Report OS versioning info on device-admin home page

### DIFF
--- a/deployments/admin/device-admin.pkg/deployment.compose.yml
+++ b/deployments/admin/device-admin.pkg/deployment.compose.yml
@@ -17,6 +17,10 @@ services:
       #   target: /web/templates
       #   read_only: true
       - type: bind
+        source: /run/versioning
+        target: /run/versioning
+        read_only: true
+      - type: bind
         source: /run/dbus/system_bus_socket
         target: /var/run/dbus/system_bus_socket
       - type: bind

--- a/deployments/admin/device-admin.pkg/deployment.compose.yml
+++ b/deployments/admin/device-admin.pkg/deployment.compose.yml
@@ -1,7 +1,7 @@
 services:
 
   server:
-    image: ghcr.io/openuc2/device-admin:0.1.6-alpha.5@sha256:6916b5d0e6a0f3b757de17ae8b0a8ed52b2cc02dd9c31d1ccb8f0dc927414169
+    image: ghcr.io/openuc2/device-admin:0.1.6-alpha.6@sha256:bc6c204ff1b6c90071ed414d0c8e7f94bd4a010873e594dc02386891a968ac7f
     command: server
     user: 1000:1000
     environment:
@@ -36,7 +36,7 @@ services:
         condition: service_completed_successfully
 
   sidecar:
-    image: ghcr.io/openuc2/device-admin:0.1.6-alpha.5@sha256:6916b5d0e6a0f3b757de17ae8b0a8ed52b2cc02dd9c31d1ccb8f0dc927414169
+    image: ghcr.io/openuc2/device-admin:0.1.6-alpha.6@sha256:bc6c204ff1b6c90071ed414d0c8e7f94bd4a010873e594dc02386891a968ac7f
     command: sidecar
     environment:
       - SIDECAR_ADDRESS=tcp:0.0.0.0:2312

--- a/deployments/admin/device-admin.pkg/deployment.compose.yml
+++ b/deployments/admin/device-admin.pkg/deployment.compose.yml
@@ -1,7 +1,7 @@
 services:
 
   server:
-    image: ghcr.io/openuc2/device-admin:0.1.6-alpha.6@sha256:bc6c204ff1b6c90071ed414d0c8e7f94bd4a010873e594dc02386891a968ac7f
+    image: ghcr.io/openuc2/device-admin:0.1.6-alpha.7@sha256:a46ebac5ba979eee88976c89416e83fdca4f146dd58de8f6078f15ad6db5e4e5
     command: server
     user: 1000:1000
     environment:
@@ -44,7 +44,7 @@ services:
         condition: service_completed_successfully
 
   sidecar:
-    image: ghcr.io/openuc2/device-admin:0.1.6-alpha.6@sha256:bc6c204ff1b6c90071ed414d0c8e7f94bd4a010873e594dc02386891a968ac7f
+    image: ghcr.io/openuc2/device-admin:0.1.6-alpha.7@sha256:a46ebac5ba979eee88976c89416e83fdca4f146dd58de8f6078f15ad6db5e4e5
     command: sidecar
     environment:
       - SIDECAR_ADDRESS=tcp:0.0.0.0:2312

--- a/deployments/admin/device-admin.pkg/deployment.compose.yml
+++ b/deployments/admin/device-admin.pkg/deployment.compose.yml
@@ -21,6 +21,14 @@ services:
         target: /run/versioning
         read_only: true
       - type: bind
+        source: /run/machine-name
+        target: /run/machine-name
+        read_only: true
+      - type: bind
+        source: /etc/hostname
+        target: /etc/hostname
+        read_only: true
+      - type: bind
         source: /run/dbus/system_bus_socket
         target: /var/run/dbus/system_bus_socket
       - type: bind

--- a/deployments/infra/forklift.pkg/forklift-package.yml
+++ b/deployments/infra/forklift.pkg/forklift-package.yml
@@ -7,6 +7,20 @@ package:
   sources:
     - https://github.com/forklift-run/forklift
 
+deployment:
+  provides:
+    file-exports:
+      - description: Shell script to report Forklift-related versioning information
+        target: overlays/usr/libexec/report-versioning-forklift
+      - description: systemd service to run the report-versioning-forklift script during boot
+        target: overlays/usr/lib/systemd/system/report-versioning-forklift.service
+      - description: systemd service enablement for report-versioning-forklift.service
+        target: overlays/etc/systemd/system/multi-user.target.wants/report-versioning-forklift.service
+      - description: systemdm timer to periodically regenerate Forklift-related versioning report
+        target: overlays/usr/lib/systemd/system/report-versioning-forklift.timer
+      - description: systemd service enablement for report-versioning-forklift.timer
+        target: overlays/etc/systemd/system/multi-user.target.wants/report-versioning-forklift.timer
+
 features:
   motd:
     provides:

--- a/deployments/infra/forklift.pkg/overlays/etc/systemd/system/multi-user.target.wants/report-versioning-forklift.service
+++ b/deployments/infra/forklift.pkg/overlays/etc/systemd/system/multi-user.target.wants/report-versioning-forklift.service
@@ -1,0 +1,1 @@
+../../../../usr/lib/systemd/system/report-versioning-forklift.service

--- a/deployments/infra/forklift.pkg/overlays/etc/systemd/system/multi-user.target.wants/report-versioning-forklift.timer
+++ b/deployments/infra/forklift.pkg/overlays/etc/systemd/system/multi-user.target.wants/report-versioning-forklift.timer
@@ -1,0 +1,1 @@
+../../../../usr/lib/systemd/system/report-versioning-forklift.timer

--- a/deployments/infra/forklift.pkg/overlays/usr/lib/systemd/system/report-versioning-forklift.service
+++ b/deployments/infra/forklift.pkg/overlays/usr/lib/systemd/system/report-versioning-forklift.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Report Forklift-related versioning info
+ConditionFileIsExecutable=/usr/libexec/report-versioning-forklift
+
+[Service]
+Type=oneshot
+ExecStartPre=mkdir -p /run/versioning
+ExecStartPre=chmod a+rx /run/versioning
+ExecStart=bash -c "/usr/libexec/report-versioning-forklift > /run/versioning/forklift.yml"
+ExecStartPost=chmod a+r /run/versioning/forklift.yml
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/deployments/infra/forklift.pkg/overlays/usr/lib/systemd/system/report-versioning-forklift.service
+++ b/deployments/infra/forklift.pkg/overlays/usr/lib/systemd/system/report-versioning-forklift.service
@@ -8,7 +8,6 @@ ExecStartPre=mkdir -p /run/versioning
 ExecStartPre=chmod a+rx /run/versioning
 ExecStart=bash -c "/usr/libexec/report-versioning-forklift > /run/versioning/forklift.yml"
 ExecStartPost=chmod a+r /run/versioning/forklift.yml
-RemainAfterExit=yes
 
 [Install]
 WantedBy=multi-user.target

--- a/deployments/infra/forklift.pkg/overlays/usr/lib/systemd/system/report-versioning-forklift.timer
+++ b/deployments/infra/forklift.pkg/overlays/usr/lib/systemd/system/report-versioning-forklift.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Report Forklift-related versioning info
+
+[Timer]
+Unit=report-versioning-forklift.service
+OnActiveSec=0
+OnUnitActiveSec=60
+
+[Install]
+WantedBy=multi-user.target

--- a/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
+++ b/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
@@ -117,7 +117,7 @@ fi
 echo -e "pallet: \"$local_plt_path@$local_plt_version\""
 if [ "$local_plt_changes" != "" ]; then
   echo -e "changes: |"
-  echo -e "$local_plt_changes"
+  echo -e "$local_plt_changes" | sed 's~^~  ~'
 fi
 if [ "$upgrade_query" == "" ]; then
   echo "# warning: couldn't determine the upgrade query to check for upgrades!"

--- a/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
+++ b/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
@@ -83,33 +83,48 @@ assemble_pallet_identifier() {
   echo "$result"
 }
 
-if [ "$forklift_version" != "" ]; then
+if [ "$forklift_version" == "" ]; then
+  echo "# error: couldn't determine the active version of Forklift!"
+else
   echo "forklift: \"$forklift_version\""
 fi
-if [ "$factory_reset_bun" != "" ]; then
+if [ "$factory_reset_bun" == "" ]; then
+  echo "# error: couldn't determine the originally-installed version of the OS!"
+else
   echo -e "factory: \"$(assemble_pallet_identifier "$factory_reset_bun")\""
 fi
-if [ "$current_bun" != "" ]; then
+if [ "$current_bun" == "" ]; then
+  echo "# error: couldn't determine the currently-booted Forklift pallet!"
+else
   if [ "$(systemctl is-system-running)" == "starting" ]; then
     echo -e "previous: \"$(assemble_pallet_identifier "$current_bun")\""
   else
     echo -e "current: \"$(assemble_pallet_identifier "$current_bun")\""
   fi
 fi
-if [ "$next_bun" != "" && "$next_bun" != "$current_bun" ]; then
+if [ "$next_bun" == "" ]; then
+  echo "# error: couldn't determine the next Forklift pallet to boot into!"
+elif [ "$next_bun" != "$current_bun" ]; then
   if [ "$(systemctl is-system-running)" == "starting" ]; then
     echo -e "current: \"$(assemble_pallet_identifier "$next_bun")\""
   else
     echo -e "pending: \"$(assemble_pallet_identifier "$next_bun")\""
     if [ "$next_failed" == "true" ]; then
-      echo -e "warning: Because the pending version had already failed during a past boot attempt, future boots will instead fall back to the currently-booted version. You can try the pending version again on the next boot, by running: forklift stage set-next-result pending"
+      echo -e "# warning: because the pending version had already failed during a past boot attempt, future boots will instead fall back to the currently-booted version. You can try the pending version again on the next boot, by running: forklift stage set-next-result pending"
     fi
   fi
 fi
 echo -e "pallet: \"$local_plt_path@$local_plt_version\""
-if [ "$upgrade_query" != "" ]; then
+if [ "$local_plt_changes" != "" ]; then
+  echo -e "changes: |"
+  echo -e "$local_plt_changes"
+fi
+if [ "$upgrade_query" == "" ]; then
+  echo "# warning: couldn't determine the upgrade query to check for upgrades!"
+else
   echo "upgrade-source: \"$upgrade_query\""
 fi
 if [ "$upgrade_available" != "" ]; then
   echo -e "upgrade: \"$upgrade_available\""
+  echo "# to install update, run: forklift plt upgrade && sudo systemctl soft-reboot"
 fi

--- a/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
+++ b/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
@@ -3,10 +3,6 @@
 export FORKLIFT_STAGE_STORE=/var/lib/forklift/stages
 export FORKLIFT_WORKSPACE=/home/pi
 
-green_color="\e[0;32m"
-purple_color="\e[0;35m"
-reset_color="\033[0m"
-
 forklift_version=""
 local_plt_dir=""
 upgrade_query=""
@@ -19,7 +15,7 @@ if which forklift >/dev/null; then
   upgrade_available="$(
     sudo -u pi forklift plt check-upgrade |
       sed 's~^.* -> ~~'
-  )" # TODO: cache this in the filesystem for faster MOTD generation! Otherwise, connecting by SSH is a bit slower.
+  )" # TODO: cache this in the filesystem
 fi
 
 factory_reset_bun=""
@@ -68,7 +64,7 @@ if [ "$local_plt_dir" != "" ] && which forklift >/dev/null && which git >/dev/nu
 
   local_plt_changes="$(sudo -u pi git -C "$local_plt_dir" status --porcelain)"
   if [ "$local_plt_changes" != "" ]; then
-    local_plt_version="$local_plt_version ${purple_color}with uncommitted changes$reset_color:"
+    local_plt_version="$local_plt_version with uncommitted changes"
   fi
 fi
 
@@ -81,55 +77,39 @@ assemble_pallet_identifier() {
   is_clean="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.clean" -r)"
   result="$pallet_path@$pallet_version"
   if [ "$is_clean" != "true" ]; then
-    result="$result ${purple_color}with uncommitted changes$reset_color"
+    result="$result with uncommitted changes"
   fi
 
   echo "$result"
 }
 
-echo
-if [ "$forklift_version" == "" ]; then
-  echo "Couldn't determine the active version of Forklift!"
-else
-  echo "Forklift: $forklift_version"
+if [ "$forklift_version" != "" ]; then
+  echo "forklift: \"$forklift_version\""
 fi
-if [ "$factory_reset_bun" == "" ]; then
-  echo "Couldn't determine the originally-installed version of the OS!"
-else
-  echo -e "Originally installed:  $(assemble_pallet_identifier "$factory_reset_bun")"
+if [ "$factory_reset_bun" != "" ]; then
+  echo -e "factory: \"$(assemble_pallet_identifier "$factory_reset_bun")\""
 fi
-if [ "$current_bun" == "" ]; then
-  echo "Couldn't determine the currently-booted Forklift pallet!"
-else
+if [ "$current_bun" != "" ]; then
   if [ "$(systemctl is-system-running)" == "starting" ]; then
-    echo -e "Previously booted:     $(assemble_pallet_identifier "$current_bun")"
+    echo -e "previous: \"$(assemble_pallet_identifier "$current_bun")\""
   else
-    echo -e "Currently booted:      $(assemble_pallet_identifier "$current_bun")"
+    echo -e "current: \"$(assemble_pallet_identifier "$current_bun")\""
   fi
 fi
-if [ "$next_bun" == "" ]; then
-  echo "Couldn't determine the next Forklift pallet to boot into!"
-elif [ "$next_bun" != "$current_bun" ]; then
+if [ "$next_bun" != "" && "$next_bun" != "$current_bun" ]; then
   if [ "$(systemctl is-system-running)" == "starting" ]; then
-    echo -e "Currently booting:     $(assemble_pallet_identifier "$next_bun")"
+    echo -e "current: \"$(assemble_pallet_identifier "$next_bun")\""
   else
-    echo -e "${green_color}Pending for next boot: $(assemble_pallet_identifier "$next_bun")$reset_color"
+    echo -e "pending: \"$(assemble_pallet_identifier "$next_bun")\""
     if [ "$next_failed" == "true" ]; then
-      echo -e "${purple_color}Warning:$reset_color because the pending version had already failed during a past boot attempt, future boots will instead fall back to the currently-booted version."
-      echo "You can try the pending version again on the next boot, by running: forklift stage set-next-result pending"
+      echo -e "warning: Because the pending version had already failed during a past boot attempt, future boots will instead fall back to the currently-booted version. You can try the pending version again on the next boot, by running: forklift stage set-next-result pending"
     fi
   fi
 fi
-echo -e "Local pallet:          $local_plt_path@$local_plt_version"
-if [ "$local_plt_changes" != "" ]; then
-  echo -e "${purple_color}$local_plt_changes$reset_color"
-fi
-if [ "$upgrade_query" == "" ]; then
-  echo "Couldn't determine the upgrade query to check for upgrades!"
-else
-  echo "Update source:         $upgrade_query"
+echo -e "pallet: \"$local_plt_path@$local_plt_version\""
+if [ "$upgrade_query" != "" ]; then
+  echo "upgrade-source: \"$upgrade_query\""
 fi
 if [ "$upgrade_available" != "" ]; then
-  echo -e "${green_color}Update available:      $upgrade_available$reset_color"
-  echo "To install update, run: forklift plt upgrade && sudo systemctl soft-reboot"
+  echo -e "upgrade: \"$upgrade_available\""
 fi

--- a/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
+++ b/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
@@ -116,7 +116,7 @@ elif [ "$next_bun" != "$current_bun" ]; then
 fi
 echo -e "pallet: \"$local_plt_path@$local_plt_version\""
 if [ "$local_plt_changes" != "" ]; then
-  echo -e "changes: |"
+  echo -e "changes: |2"
   echo -e "$local_plt_changes" | sed 's~^~  ~'
 fi
 if [ "$upgrade_query" == "" ]; then


### PR DESCRIPTION
This PR integrates https://github.com/openUC2/device-admin/pull/46 (and follow-up commits https://github.com/openUC2/device-admin/commit/36ec647ed10f7ba8ef34486c37915a7804359c3b & https://github.com/openUC2/device-admin/commit/5c3402589c0f8ba064b2654203f265f4108e1293) by bumping the device-admin ctr img and adding a systemd service+timer to periodically write/update `/run/versioning/forklift.yml` .

This work is tracked on Notion at https://www.notion.so/Report-OS-version-in-Machine-Admin-app-3224e612c78a800dab9fc247600fb01c?source=copy_link .