### PR TITLE
Bind-mount `/dev` into the imswitch ctr

### DIFF
--- a/deployments/imswitch.pkg/deployment.compose.yml
+++ b/deployments/imswitch.pkg/deployment.compose.yml
@@ -8,6 +8,9 @@ services:
       - /home/pi/Datasets:/home/pi/Datasets
       - /media:/media
       - /run/udev:/run/udev:ro
+      # For scanning and accessing USB serial devices:
+      - /dev:/dev
+      # For libcamera:
       - /dev/dma_heap:/dev/dma_heap
       - type: bind
         source: /run/versioning


### PR DESCRIPTION
This PR attempts to resolve issues with searching USB serial devices from inside the ImSwitch container.