### PR TITLE
Enable configuration of whether to sysroot mounts should be read-only

### DIFF
--- a/deployments/infra/machine-portal.pkg/templates/home/index.advanced.page.tmpl
+++ b/deployments/infra/machine-portal.pkg/templates/home/index.advanced.page.tmpl
@@ -61,7 +61,7 @@
               template "shared/link.partial.tmpl" dict
               "Href" "/admin/panel/"
               "Name" "Machine Administration"
-              "Description" "The main system-administration dashboard for this machine"
+              "Description" "The main system-administration interface for this machine's operating system"
             }}
           </li>
         </ul>
@@ -213,7 +213,7 @@
               template "shared/link.partial.tmpl" dict
               "Href" "/admin/panel/?mode=advanced"
               "Name" "Machine Administration (advanced mode)"
-              "Description" "The main system-administration dashboard for this machine, with advanced information and settings"
+              "Description" "The main system-administration interface for this machine's operating system, with advanced information and settings"
             }}
           </li>
           <li>

--- a/deployments/infra/machine-portal.pkg/templates/home/index.page.tmpl
+++ b/deployments/infra/machine-portal.pkg/templates/home/index.page.tmpl
@@ -50,7 +50,7 @@
               template "shared/link.partial.tmpl" dict
               "Href" "/admin/panel/"
               "Name" "Machine Administration"
-              "Description" "The main system-administration dashboard for this machine"
+              "Description" "The main system-administration interface for this machine's operating system"
             }}
           </li>
         </ul>

--- a/os-build/forklift/boot/firmware/sysroot-mounts/README.md
+++ b/os-build/forklift/boot/firmware/sysroot-mounts/README.md
@@ -1,0 +1,40 @@
+# sysroot-mounts
+
+By default, `/sysroot/etc` and `/sysroot/usr` are mounted in read-only mode as the base of Forklift overlays for `/etc` and `/usr`, respectively.
+However, in certain exceptional situations (e.g. when kernel drivers need to be installed for Wi-Fi dongles, or when doing lower-level troubleshooting of nasty issues) it is useful to directly modify `/sysroot/etc` and/or `/sysroot/usr`.
+
+## `/sysroot/etc`
+
+To enable direct modification of `/sysroot/etc`, run:
+
+```bash
+sudo touch /boot/firmware/sysroot-mounts/etc-rw
+sudo systemctl soft-reboot
+```
+
+To disable further direct modification of `/sysroot/etc`, run:
+
+```bash
+sudo rm /boot/firmware/sysroot-mounts/etc-rw
+sudo systemctl soft-reboot
+```
+
+You can always re-enable and re-disable direct modification of `/sysroot/etc` using these commands.
+
+## `/sysroot/usr`
+
+To enable direct modification of `/sysroot/usr`, run:
+
+```bash
+sudo touch /boot/firmware/sysroot-mounts/usr-rw
+sudo systemctl soft-reboot
+```
+
+To disable further direct modification of `/sysroot/usr`, run:
+
+```bash
+sudo rm /boot/firmware/sysroot-mounts/usr-rw
+sudo systemctl soft-reboot
+```
+
+You can always re-enable and re-disable direct modification of `/sysroot/usr` using these commands.

--- a/os-build/forklift/install.sh
+++ b/os-build/forklift/install.sh
@@ -84,4 +84,7 @@ sudo systemctl preset \
   overlay-etc.service \
   start-overlaid-units.service \
   fake-hwclock-overlay-support.service
-sudo mkdir -p /boot/firmware/sysroot-mounts # for configuring overlay-usr & overlay-etc behavior
+# Set up configurability of overlay-usr & overlay-etc behavior
+file="/boot/firmware/sysroot-mounts/README.md"
+sudo mkdir -p "$(dirname "$file")"
+sudo cp "$config_files_root$file" "$file"

--- a/os-build/forklift/install.sh
+++ b/os-build/forklift/install.sh
@@ -84,3 +84,4 @@ sudo systemctl preset \
   overlay-etc.service \
   start-overlaid-units.service \
   fake-hwclock-overlay-support.service
+sudo mkdir -p /boot/firmware/sysroot-mounts # for configuring overlay-usr & overlay-etc behavior

--- a/os-build/forklift/usr/lib/systemd/system/overlay-etc.service
+++ b/os-build/forklift/usr/lib/systemd/system/overlay-etc.service
@@ -26,8 +26,15 @@ ExecStartPre=mkdir -p $UPPERDIR
 Environment=TARGET=/etc
 ExecStartPre=mkdir -p /sysroot${TARGET}
 ExecStart=mount --bind $TARGET /sysroot${TARGET}
-# Prevent changes to the contents in /sysroot:
-ExecStart=mount -o bind,remount,ro /sysroot${TARGET}
+# Prevent changes to the contents in /sysroot unless /boot/firmware/sysroot-mounts/etc-rw exists:
+ExecStart=bash -c -e '\
+if [ -f /boot/firmware/sysroot-mounts${TARGET}-rw ]; then \
+echo "Mounted /sysroot${TARGET} as read-write!" \
+else \
+echo "Mounting /sysroot${TARGET} as read-only..." \
+mount -o bind,remount,ro /sysroot${TARGET}; \
+fi \
+'
 # Prevent the overlay mount from also being created onto the directory in /sysroot:
 ExecStart=mount --make-private /sysroot/${TARGET}
 Environment=FORKLIFT_STAGE_STORE=/var/lib/forklift/stages
@@ -35,11 +42,11 @@ Environment=FORKLIFT_STAGE_STORE=/var/lib/forklift/stages
 # mounted! Doing so causes undefined behavior, i.e. weirdness and inconsistency
 # (see https://docs.kernel.org/filesystems/overlayfs.html#changes-to-underlying-filesystems).
 ExecStart=bash -c -e '\
-  LOWERDIR_FORKLIFT=$(forklift stage locate-bundle next)/exports/overlays/etc; \
-  LOWERDIRS="/sysroot$TARGET"; \
-  if [ -d $LOWERDIR_FORKLIFT ]; then LOWERDIRS="$LOWERDIR_FORKLIFT:$LOWERDIRS"; fi; \
-  echo "Overlay lower directories: $LOWERDIRS"; \
-  mount -t overlay overlay -o workdir=$WORKDIR,upperdir=$UPPERDIR,lowerdir=$LOWERDIRS $TARGET \
+LOWERDIR_FORKLIFT=$(forklift stage locate-bundle next)/exports/overlays/etc; \
+LOWERDIRS="/sysroot$TARGET"; \
+if [ -d $LOWERDIR_FORKLIFT ]; then LOWERDIRS="$LOWERDIR_FORKLIFT:$LOWERDIRS"; fi; \
+echo "Overlay lower directories: $LOWERDIRS"; \
+mount -t overlay overlay -o workdir=$WORKDIR,upperdir=$UPPERDIR,lowerdir=$LOWERDIRS $TARGET \
 '
 # Immediately update any systemd units added by the overlay:
 ExecStart=systemctl daemon-reload

--- a/os-build/forklift/usr/lib/systemd/system/overlay-etc.service
+++ b/os-build/forklift/usr/lib/systemd/system/overlay-etc.service
@@ -28,12 +28,12 @@ ExecStartPre=mkdir -p /sysroot${TARGET}
 ExecStart=mount --bind $TARGET /sysroot${TARGET}
 # Prevent changes to the contents in /sysroot unless /boot/firmware/sysroot-mounts/etc-rw exists:
 ExecStart=bash -c -e '\
-if [ -f /boot/firmware/sysroot-mounts${TARGET}-rw ]; then \
-echo "Mounted /sysroot${TARGET} as read-write!" \
-else \
-echo "Mounting /sysroot${TARGET} as read-only..." \
-mount -o bind,remount,ro /sysroot${TARGET}; \
-fi \
+  if [ -f /boot/firmware/sysroot-mounts${TARGET}-rw ]; then \
+    echo "Mounted /sysroot${TARGET} as read-write!"; \
+  else \
+    echo "Mounting /sysroot${TARGET} as read-only..."; \
+    mount -o bind,remount,ro /sysroot${TARGET}; \
+  fi \
 '
 # Prevent the overlay mount from also being created onto the directory in /sysroot:
 ExecStart=mount --make-private /sysroot/${TARGET}
@@ -42,11 +42,11 @@ Environment=FORKLIFT_STAGE_STORE=/var/lib/forklift/stages
 # mounted! Doing so causes undefined behavior, i.e. weirdness and inconsistency
 # (see https://docs.kernel.org/filesystems/overlayfs.html#changes-to-underlying-filesystems).
 ExecStart=bash -c -e '\
-LOWERDIR_FORKLIFT=$(forklift stage locate-bundle next)/exports/overlays/etc; \
-LOWERDIRS="/sysroot$TARGET"; \
-if [ -d $LOWERDIR_FORKLIFT ]; then LOWERDIRS="$LOWERDIR_FORKLIFT:$LOWERDIRS"; fi; \
-echo "Overlay lower directories: $LOWERDIRS"; \
-mount -t overlay overlay -o workdir=$WORKDIR,upperdir=$UPPERDIR,lowerdir=$LOWERDIRS $TARGET \
+  LOWERDIR_FORKLIFT=$(forklift stage locate-bundle next)/exports/overlays/etc; \
+  LOWERDIRS="/sysroot$TARGET"; \
+  if [ -d $LOWERDIR_FORKLIFT ]; then LOWERDIRS="$LOWERDIR_FORKLIFT:$LOWERDIRS"; fi; \
+  echo "Overlay lower directories: $LOWERDIRS"; \
+  mount -t overlay overlay -o workdir=$WORKDIR,upperdir=$UPPERDIR,lowerdir=$LOWERDIRS $TARGET \
 '
 # Immediately update any systemd units added by the overlay:
 ExecStart=systemctl daemon-reload

--- a/os-build/forklift/usr/lib/systemd/system/overlay-usr.service
+++ b/os-build/forklift/usr/lib/systemd/system/overlay-usr.service
@@ -21,8 +21,15 @@ ExecStartPre=mkdir -p $UPPERDIR
 Environment=TARGET=/usr
 ExecStartPre=mkdir -p /sysroot${TARGET}
 ExecStart=mount --bind $TARGET /sysroot${TARGET}
-# Prevent changes to the contents in /sysroot:
-ExecStart=mount -o bind,remount,ro /sysroot${TARGET}
+# Prevent changes to the contents in /sysroot unless /boot/firmware/sysroot-mounts/usr exists:
+ExecStart=bash -c -e '\
+  if [ -f /boot/firmware/sysroot-mounts${TARGET}-rw ]; then \
+    echo "Mounted /sysroot${TARGET} as read-write!" \
+  else \
+    echo "Mounting /sysroot${TARGET} as read-only..." \
+    mount -o bind,remount,ro /sysroot${TARGET}; \
+  fi \
+'
 # Prevent the overlay mount from also being created onto the directory in /sysroot:
 ExecStart=mount --make-private /sysroot/${TARGET}
 Environment=FORKLIFT_STAGE_STORE=/var/lib/forklift/stages

--- a/os-build/forklift/usr/lib/systemd/system/overlay-usr.service
+++ b/os-build/forklift/usr/lib/systemd/system/overlay-usr.service
@@ -24,9 +24,9 @@ ExecStart=mount --bind $TARGET /sysroot${TARGET}
 # Prevent changes to the contents in /sysroot unless /boot/firmware/sysroot-mounts/usr exists:
 ExecStart=bash -c -e '\
   if [ -f /boot/firmware/sysroot-mounts${TARGET}-rw ]; then \
-    echo "Mounted /sysroot${TARGET} as read-write!" \
+    echo "Mounted /sysroot${TARGET} as read-write!"; \
   else \
-    echo "Mounting /sysroot${TARGET} as read-only..." \
+    echo "Mounting /sysroot${TARGET} as read-only..."; \
     mount -o bind,remount,ro /sysroot${TARGET}; \
   fi \
 '


### PR DESCRIPTION
This PR makes it possible to mount `/sysroot/etc` and/or `/sysroot/usr` as writeable (rather than read-only) by creating empty files at `/boot/firmware/sysroot-mounts/etc-rw` and `/boot/firmware/sysroot-mounts/usr-rw`, respectively. This way, we can apply low-level OS changes which need to be applied before the `/etc` and `/usr` overlay mounts are created. This functionality should not be used normally; rather, it's an "in case of emergency: break glass"-style mechanism intended to be used by developers and for serious/low-level troubleshooting.

This work is tracked on Notion at https://app.notion.com/p/Make-it-possible-to-edit-early-boot-OS-files-as-a-developer-3114e612c78a806fb03ad3ad842f3f45?source=copy_link