### PR TITLE
Add platform hardware support for CAN using the MCP2515 SPI HAT

### DIFF
--- a/deployments/imswitch.deploy.yml
+++ b/deployments/imswitch.deploy.yml
@@ -4,4 +4,5 @@ features:
   - frontend-untrusted
   - firewall-allow-direct
   - firewall-allow-public
+  - can-device
 disabled: false

--- a/deployments/imswitch.pkg/forklift-package.yml
+++ b/deployments/imswitch.pkg/forklift-package.yml
@@ -120,6 +120,10 @@ features:
       file-exports:
         - description: systemd-networkd configuration for the can0 device
           target: overlays/etc/systemd/network/80-can0.network
+        - description: >-
+            systemd-networkd default configuration disablement for Wi-Fi devices in ad-hoc mode,
+            which should be managed by NetworkManager instead
+          target: overlays/etc/systemd/network/80-wifi-adhoc.network
         - description: systemd service enablement for systemd-networkd
           target: overlays/etc/systemd/system/multi-user.target.wants/systemd-networkd.service
   dev-edge:

--- a/deployments/imswitch.pkg/forklift-package.yml
+++ b/deployments/imswitch.pkg/forklift-package.yml
@@ -114,6 +114,14 @@ features:
           target: overlays/etc/firewalld/services/imswitch-dev.xml
         - description: Drop-in XML fragment for firewalld's imswitch-dev service
           target: overlays/etc/firewalld/zones.d/public/70-service-imswitch-dev.xml
+  can-device:
+    description: Provides automatic enablement of the OS interface for an SPI CAN bus transceiver
+    provides:
+      file-exports:
+        - description: systemd-networkd configuration for the can0 device
+          target: overlays/etc/systemd/network/80-can0.network
+        - description: systemd service enablement for systemd-networkd
+          target: overlays/etc/systemd/system/multi-user.target.wants/systemd-networkd.service
   dev-edge:
     description: >-
       Uses the `edge` tag for the ImSwitch docker container image, for faster development

--- a/deployments/imswitch.pkg/overlays/etc/systemd/network/80-can0.network
+++ b/deployments/imswitch.pkg/overlays/etc/systemd/network/80-can0.network
@@ -2,4 +2,4 @@
 Name=can0
 
 [CAN]
-BitRate=500k
+BitRate=500000

--- a/deployments/imswitch.pkg/overlays/etc/systemd/network/80-can0.network
+++ b/deployments/imswitch.pkg/overlays/etc/systemd/network/80-can0.network
@@ -1,0 +1,5 @@
+[Match]
+Name=can0
+
+[CAN]
+BitRate=500k

--- a/deployments/imswitch.pkg/overlays/etc/systemd/network/80-wifi-adhoc.network
+++ b/deployments/imswitch.pkg/overlays/etc/systemd/network/80-wifi-adhoc.network
@@ -1,0 +1,1 @@
+/dev/null

--- a/deployments/imswitch.pkg/overlays/etc/systemd/network/80-wifi-adhoc.network
+++ b/deployments/imswitch.pkg/overlays/etc/systemd/network/80-wifi-adhoc.network
@@ -1,1 +1,1 @@
-/dev/null
+../../../dev/null

--- a/deployments/imswitch.pkg/overlays/etc/systemd/system/multi-user.target.wants/systemd-networkd.service
+++ b/deployments/imswitch.pkg/overlays/etc/systemd/system/multi-user.target.wants/systemd-networkd.service
@@ -1,0 +1,1 @@
+../../../../usr/lib/systemd/system/systemd-networkd.service

--- a/os-build/imswitch-hardware/boot/firmware/config.txt.snippet
+++ b/os-build/imswitch-hardware/boot/firmware/config.txt.snippet
@@ -1,0 +1,4 @@
+
+# Allow the RPi 5 to talk directly over the CAN interface
+dtparam=spi=on
+dtoverlay=mcp2515-can0,oscillator=12000000,interrupt=12,spimaxfrequency=10000000

--- a/os-build/imswitch-hardware/install.sh
+++ b/os-build/imswitch-hardware/install.sh
@@ -23,3 +23,7 @@ HIK_DEB_FILE="$(mktemp --suffix=".deb")"
 curl -L "https://github.com/openUC2/ImSwitchDockerInstall/releases/download/imswitch-master/MVS-3.0.1_${HIK_ARCH}_20241128.deb" \
   >"$HIK_DEB_FILE"
 sudo dpkg -i "$HIK_DEB_FILE"
+
+# Add config.txt configuration for the CAN transceiver on the openUC2 HAT+
+file="/boot/firmware/config.txt"
+sudo bash -c "cat \"$config_files_root$file.snippet\" >> \"$file\""

--- a/os-build/platform-hardware/boot/firmware/config.txt.snippet
+++ b/os-build/platform-hardware/boot/firmware/config.txt.snippet
@@ -4,3 +4,7 @@ usb_max_current_enable=1
 
 # Allow the RPi 5 to charge an attached RTC battery
 dtparam=rtc_bbat_vhcg=3000000
+
+# Allow the RPi 5 to talk directly over the CAN interface
+dtparam=spi=on
+dtoverlay=mcp2515-can0,oscillator=12000000,interrupt=12,spimaxfrequency=10000000

--- a/os-build/platform-hardware/boot/firmware/config.txt.snippet
+++ b/os-build/platform-hardware/boot/firmware/config.txt.snippet
@@ -4,7 +4,3 @@ usb_max_current_enable=1
 
 # Allow the RPi 5 to charge an attached RTC battery
 dtparam=rtc_bbat_vhcg=3000000
-
-# Allow the RPi 5 to talk directly over the CAN interface
-dtparam=spi=on
-dtoverlay=mcp2515-can0,oscillator=12000000,interrupt=12,spimaxfrequency=10000000

--- a/os-build/tools/install.sh
+++ b/os-build/tools/install.sh
@@ -11,4 +11,7 @@ sudo -E apt-get install -y -o DPkg::Lock::Timeout=60 -o Dpkg::Progress-Fancy=0 \
 
 # Install some tools for troubleshooting networking stuff
 sudo -E apt-get install -y -o Dpkg::Progress-Fancy=0 \
-  net-tools bind9-dnsutils netcat-openbsd nmap avahi-utils
+  net-tools bind9-dnsutils netcat-openbsd nmap \
+  avahi-utils \
+  can-utils
+


### PR DESCRIPTION
This PR adds support for the MCP2515 SPI HAT as a way for the RPi to talk directly to peripheral devices over CAN.

TODO:
- [x] determine whether we can use NetworkManager or systemd-networkd to automatically activate the can0 device, since it's not auto-activated
- [x] determine whether we need to add a system service to switch the link to 500 kbps: `sudo ip link set can0 up type can bitrate 500000 restart-ms 100;
ip -details link show can0`

This work was requested by @beniroquai in [#teams/software > general chat @ 💬](https://chat.openuc2.com/#narrow/channel/4-teams.2Fsoftware/topic//near/4009). This work is tracked on Notion at https://app.notion.com/p/Add-CAN-bus-support-to-the-OS-37b4e612c78a8056bcdcfec2e44b0eb1?source=copy_link.