### PR TITLE
Try to retain branch info in local plt in PR-triggered OS builds

### DIFF
--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -47,7 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-    if: ${{ github.event_name == 'release' }}
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -71,7 +71,8 @@ jobs:
       - name: Fetch all branches
         run: |
           git fetch --all
-          for remote in `git branch -r`; do
+          git branch --all
+          for remote in "$(git branch -r | grep -v '\->' | sed "s~\x1B\[[0-9;]*[a-zA-Z]~~g")"; do
             git branch --track ${remote#origin/} $remote
           done
           git branch --all

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -77,6 +77,7 @@ jobs:
             matching_branch="$(head -n 1 <<< "$matching_branches")"
             local_branch="${matching_branch#origin/}"
             git branch "$local_branch"
+            git branch -a -v
             git branch -u "$matching_branch" "$local_branch"
             git branch -a -v
             git switch "$local_branch"

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -65,9 +65,14 @@ jobs:
           # We fetch tags so that the staged pallet bundle has a record of ancestral tags, for
           # pseudoversion string generation:
           fetch-tags: true
-          # We fetch the history of all branches so that the OS image's local pallet will know if
-          # the commit it's on is on a branch (e.g. for an image built from a PR)
-          fetch-depth: 0
+
+      # We pull all branches so that the OS image's local pallet will know if its current commit is
+      # actually on a branch (e.g. for an image built from a PR-triggered CI run)
+      - name: Fetch all branches
+        run: |
+          for remote in `git branch -r`; do
+            git branch --track ${remote#origin/} $remote
+          done
 
       # GET BASE IMAGE
 

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -65,6 +65,9 @@ jobs:
           # We fetch tags so that the staged pallet bundle has a record of ancestral tags, for
           # pseudoversion string generation:
           fetch-tags: true
+          # We fetch the history of all branches so that the OS image's local pallet will know if
+          # the commit it's on is on a branch (e.g. for an image built from a PR)
+          fetch-depth: 0
 
       # GET BASE IMAGE
 

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -75,9 +75,11 @@ jobs:
           echo $matching_branches
           if [[ -n "$matching_branches" ]]; then
             matching_branch="$(head -n 1 <<< "$matching_branches")"
-            git branch --track "${matching_branch#origin/}" $matching_branch
+            local_branch="${matching_branch#origin/}"
+            git branch "$local_branch"
+            git branch -u $matching_branch
             git branch -a -v
-            git switch "${matching_branch#origin/}"
+            git switch "$local_branch"
             git branch -v
           fi
 

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -70,9 +70,11 @@ jobs:
       # actually on a branch (e.g. for an image built from a PR-triggered CI run)
       - name: Fetch all branches
         run: |
+          set -x
           git fetch --all
-          git branch --all
+          git branch -a
           for remote in "$(git branch -r | grep -v '\->' | sed "s~\x1B\[[0-9;]*[a-zA-Z]~~g")"; do
+            echo "Tracking $remote..."
             git branch --track ${remote#origin/} $remote
           done
           git branch --all

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -66,18 +66,18 @@ jobs:
           # pseudoversion string generation:
           fetch-tags: true
 
-      # We pull all branches so that the OS image's local pallet will know if its current commit is
-      # actually on a branch (e.g. for an image built from a PR-triggered CI run)
-      - name: Fetch all branches
+      - name: Use branch of PR commit
+        if: ${{ github.event.pull_request.head.sha }}
         run: |
           set -x
-          git fetch --all
-          git branch -a
-          for remote in "$(git branch -r | grep -v '\->' | sed "s~\x1B\[[0-9;]*[a-zA-Z]~~g")"; do
-            echo "Tracking $remote..."
-            git branch --track ${remote#origin/} $remote
-          done
-          git branch --all
+          matching_branches="$(git branch -r --contains | sed 's~^[* ]*~~')"
+          echo "Branches with the current commit:"
+          echo $matching_branches
+          if [[ -n "$matching_branches" ]]; then
+            matching_branch="$(head -n 1 <<< "$matching_branches")"
+            git branch --track "${matching_branch#origin/}" $matching_branch
+            git branch --all
+          fi
 
       # GET BASE IMAGE
 

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -76,7 +76,9 @@ jobs:
           if [[ -n "$matching_branches" ]]; then
             matching_branch="$(head -n 1 <<< "$matching_branches")"
             git branch --track "${matching_branch#origin/}" $matching_branch
-            git branch --all
+            git branch -a -v
+            git switch "${matching_branch#origin/}"
+            git branch -v
           fi
 
       # GET BASE IMAGE

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -77,7 +77,7 @@ jobs:
             matching_branch="$(head -n 1 <<< "$matching_branches")"
             local_branch="${matching_branch#origin/}"
             git branch "$local_branch"
-            git branch -u $matching_branch
+            git branch -u "$matching_branch" "$local_branch"
             git branch -a -v
             git switch "$local_branch"
             git branch -v

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -70,9 +70,11 @@ jobs:
       # actually on a branch (e.g. for an image built from a PR-triggered CI run)
       - name: Fetch all branches
         run: |
+          git fetch --all
           for remote in `git branch -r`; do
             git branch --track ${remote#origin/} $remote
           done
+          git branch --all
 
       # GET BASE IMAGE
 

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -70,8 +70,8 @@ jobs:
         if: ${{ github.event.pull_request.head.sha }}
         run: |
           set -x
+          git fetch --all
           matching_branches="$(git branch -r --contains | sed 's~^[* ]*~~')"
-          echo "Branches with the current commit:"
           echo $matching_branches
           if [[ -n "$matching_branches" ]]; then
             matching_branch="$(head -n 1 <<< "$matching_branches")"

--- a/.github/workflows/build-os.yml
+++ b/.github/workflows/build-os.yml
@@ -65,6 +65,9 @@ jobs:
           # We fetch tags so that the staged pallet bundle has a record of ancestral tags, for
           # pseudoversion string generation:
           fetch-tags: true
+          # We fetch the entire history so that the full history is available in the local pallet,
+          # for reporting version information:
+          fetch-depth: 0
 
       - name: Use branch of PR commit
         if: ${{ github.event.pull_request.head.sha }}

--- a/deployments/infra/forklift.pkg/overlays/etc/update-motd.d/50-forklift
+++ b/deployments/infra/forklift.pkg/overlays/etc/update-motd.d/50-forklift
@@ -78,6 +78,10 @@ assemble_pallet_identifier() {
   bundle_manifest="$(cat "$bundle_path/forklift-bundle.yml")"
   pallet_path="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.path" -r)"
   pallet_version="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.version" -r)"
+  pallet_branch="$(sudo -u pi git -C "$bundle_path/pallet" symbolic-ref -q --short HEAD)"
+  if [ "$pallet_branch" != ""]; then
+    pallet_version="$pallet_version (branch: $pallet_branch)"
+  fi
   is_clean="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.clean" -r)"
   result="$pallet_path@$pallet_version"
   if [ "$is_clean" != "true" ]; then

--- a/deployments/infra/forklift.pkg/overlays/etc/update-motd.d/50-forklift
+++ b/deployments/infra/forklift.pkg/overlays/etc/update-motd.d/50-forklift
@@ -79,7 +79,7 @@ assemble_pallet_identifier() {
   pallet_path="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.path" -r)"
   pallet_version="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.version" -r)"
   pallet_branch="$(sudo -u pi git -C "$bundle_path/pallet" symbolic-ref -q --short HEAD)"
-  if [ "$pallet_branch" != ""]; then
+  if [ "$pallet_branch" != "" ]; then
     pallet_version="$pallet_version (branch: $pallet_branch)"
   fi
   is_clean="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.clean" -r)"

--- a/deployments/infra/forklift.pkg/overlays/etc/update-motd.d/50-forklift
+++ b/deployments/infra/forklift.pkg/overlays/etc/update-motd.d/50-forklift
@@ -78,7 +78,7 @@ assemble_pallet_identifier() {
   bundle_manifest="$(cat "$bundle_path/forklift-bundle.yml")"
   pallet_path="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.path" -r)"
   pallet_version="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.version" -r)"
-  pallet_branch="$(sudo -u pi git -C "$bundle_path/pallet" symbolic-ref -q --short HEAD)"
+  pallet_branch="$(git -C "$bundle_path/pallet" symbolic-ref -q --short HEAD)"
   if [ "$pallet_branch" != "" ]; then
     pallet_version="$pallet_version (branch: $pallet_branch)"
   fi

--- a/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
+++ b/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
@@ -74,6 +74,10 @@ assemble_pallet_identifier() {
   bundle_manifest="$(cat "$bundle_path/forklift-bundle.yml")"
   pallet_path="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.path" -r)"
   pallet_version="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.version" -r)"
+  pallet_branch = "$(sudo -u pi git -C "$bundle_path/pallet" symbolic-ref -q --short HEAD)"
+  if [ "$pallet_branch" != ""]; then
+    pallet_version="$pallet_version (branch: $pallet_branch)"
+  fi
   is_clean="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.clean" -r)"
   result="$pallet_path@$pallet_version"
   if [ "$is_clean" != "true" ]; then

--- a/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
+++ b/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
@@ -74,7 +74,7 @@ assemble_pallet_identifier() {
   bundle_manifest="$(cat "$bundle_path/forklift-bundle.yml")"
   pallet_path="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.path" -r)"
   pallet_version="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.version" -r)"
-  pallet_branch="$(sudo -u pi git -C "$bundle_path/pallet" symbolic-ref -q --short HEAD)"
+  pallet_branch="$(git -C "$bundle_path/pallet" symbolic-ref -q --short HEAD)"
   if [ "$pallet_branch" != "" ]; then
     pallet_version="$pallet_version (branch: $pallet_branch)"
   fi

--- a/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
+++ b/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
@@ -75,7 +75,7 @@ assemble_pallet_identifier() {
   pallet_path="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.path" -r)"
   pallet_version="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.version" -r)"
   pallet_branch="$(sudo -u pi git -C "$bundle_path/pallet" symbolic-ref -q --short HEAD)"
-  if [ "$pallet_branch" != ""]; then
+  if [ "$pallet_branch" != "" ]; then
     pallet_version="$pallet_version (branch: $pallet_branch)"
   fi
   is_clean="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.clean" -r)"

--- a/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
+++ b/deployments/infra/forklift.pkg/overlays/usr/libexec/report-versioning-forklift
@@ -74,7 +74,7 @@ assemble_pallet_identifier() {
   bundle_manifest="$(cat "$bundle_path/forklift-bundle.yml")"
   pallet_path="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.path" -r)"
   pallet_version="$(echo "$bundle_manifest" | gojq --yaml-input ".pallet.version" -r)"
-  pallet_branch = "$(sudo -u pi git -C "$bundle_path/pallet" symbolic-ref -q --short HEAD)"
+  pallet_branch="$(sudo -u pi git -C "$bundle_path/pallet" symbolic-ref -q --short HEAD)"
   if [ "$pallet_branch" != ""]; then
     pallet_version="$pallet_version (branch: $pallet_branch)"
   fi

--- a/deployments/infra/machine-name.pkg/overlays/usr/lib/systemd/system/update-hostname.service
+++ b/deployments/infra/machine-name.pkg/overlays/usr/lib/systemd/system/update-hostname.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Make systemd-hostnamed update the hostname from /etc/hostname
-DefaultDependencies=no
 ConditionPathExists=/etc/hostname
 Wants=generate-hostname-templated.service
 After=generate-hostname-templated.service
@@ -14,6 +13,7 @@ Before=avahi-daemon.socket
 [Service]
 Type=oneshot
 ExecStart=sh -c 'hostnamectl hostname "$(cat /etc/hostname)"'
+ExecStartPost=sh -c 'systemctl try-restart --no-block avahi-daemon.service'
 RemainAfterExit=yes
 
 [Install]

--- a/deployments/infra/machine-name.pkg/overlays/usr/lib/systemd/system/update-hostname.service
+++ b/deployments/infra/machine-name.pkg/overlays/usr/lib/systemd/system/update-hostname.service
@@ -1,6 +1,5 @@
 [Unit]
 Description=Make systemd-hostnamed update the hostname from /etc/hostname
-DefaultDependencies=no
 ConditionPathExists=/etc/hostname
 Wants=generate-hostname-templated.service
 After=generate-hostname-templated.service
@@ -14,6 +13,8 @@ Before=avahi-daemon.socket
 [Service]
 Type=oneshot
 ExecStart=sh -c 'hostnamectl hostname "$(cat /etc/hostname)"'
+# Sometimes avahi-daemon starts before update-hostname after a soft-reboot; if so, we restart it:
+ExecStartPost=sh -c 'systemctl try-restart avahi-daemon.service'
 RemainAfterExit=yes
 
 [Install]

--- a/deployments/infra/machine-name.pkg/overlays/usr/lib/systemd/system/update-hostname.service
+++ b/deployments/infra/machine-name.pkg/overlays/usr/lib/systemd/system/update-hostname.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=Make systemd-hostnamed update the hostname from /etc/hostname
+DefaultDependencies=no
 ConditionPathExists=/etc/hostname
 Wants=generate-hostname-templated.service
 After=generate-hostname-templated.service
@@ -13,8 +14,6 @@ Before=avahi-daemon.socket
 [Service]
 Type=oneshot
 ExecStart=sh -c 'hostnamectl hostname "$(cat /etc/hostname)"'
-# Sometimes avahi-daemon starts before update-hostname after a soft-reboot; if so, we restart it:
-ExecStartPost=sh -c 'systemctl try-restart avahi-daemon.service'
 RemainAfterExit=yes
 
 [Install]

--- a/os-build/forklift/install.sh
+++ b/os-build/forklift/install.sh
@@ -43,6 +43,7 @@ export PATH="$tmp_bin:$PATH"
 
 pallet_path="$(yq '.pallet.path' "$HOME/.local/share/forklift/pallet/forklift-pallet.yml")"
 forklift pallet set-upgrade-query "$pallet_path@$pallet_upgrade_version_query"
+forklift pallet show
 
 # Pre-download container images without Docker
 

--- a/os-build/forklift/install.sh
+++ b/os-build/forklift/install.sh
@@ -73,6 +73,8 @@ forklift plt ls-img |
 
 export FORKLIFT_STAGE_STORE=/var/lib/forklift/stages
 sudo -E forklift stage plan
+sudo -E forklift stage apply
+forklift stage show
 sudo -E forklift stage set-next next
 
 # Use forklift on future boot sequences

--- a/os-build/forklift/install.sh
+++ b/os-build/forklift/install.sh
@@ -73,8 +73,6 @@ forklift plt ls-img |
 
 export FORKLIFT_STAGE_STORE=/var/lib/forklift/stages
 sudo -E forklift stage plan
-sudo -E forklift stage apply
-forklift stage show
 sudo -E forklift stage set-next next
 
 # Use forklift on future boot sequences


### PR DESCRIPTION
Previously, in OS images built from PR triggers, the local pallet would be on a commit of the pallet without knowing the name of the branch this commit was on. This PR attempts to retain that information.

This PR also follows up on #129 by showing the associated branch for the currently-booted pallet and the factory-reset pallet in the MOTD.