### PR TITLE
Replace broken GitHub action for uploading to Google Drive

### DIFF
--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -47,8 +47,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-    # TODO: uncomment before merging this PR:
-    # if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     permissions:
       contents: read
       actions: read

--- a/.github/workflows/build-os-trixie.yml
+++ b/.github/workflows/build-os-trixie.yml
@@ -47,7 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - build
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    # TODO: uncomment before merging this PR:
+    # if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
     permissions:
       contents: read
       actions: read
@@ -59,9 +60,9 @@ jobs:
           github-token: ${{ github.token }}
 
       - name: Upload image to Google Drive
-        uses: Jumbo810/Upload_Github_Artifacts_TO_GDrive@v2.3.4
+        uses: adityak74/google-drive-upload-git-action@v0.3
         with:
-          target: ${{ needs.build.outputs.image_name }}.img.xz
-          parent_folder_id: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}
+          filename: ${{ needs.build.outputs.image_name }}.img.xz
+          folderId: ${{ vars.GOOGLE_DRIVE_FOLDER_ID }}
           credentials: ${{ secrets.GOOGLE_SERVICE_ACCOUNT_CREDENTIALS }}
-          replace_mode: update_in_place
+          overwrite: true


### PR DESCRIPTION
The CI run for v26.0.0-alpha.4 failed to upload the built OS image to Google Drive because the CI action for doing that no longer works (because of its use of Node.js 22, which is no longer supported in GitHub Actions). This PR replaces that CI action with a different action.