### PR TITLE
Prevent Windows devices from auto-disconnecting from hotspot

### DIFF
--- a/deployments/networking/networkmanager/wifi-hotspot.deploy.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.deploy.yml
@@ -16,4 +16,5 @@ features:
   - wlan1-direct-ip-address
   - wlan0-link-local-ip-address
   - dhcp-default-route
+  - windows-ncsi-active-probing
 disabled: false

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/deployment.compose.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/deployment.compose.yml
@@ -1,0 +1,8 @@
+services:
+  reverse-proxy-config:
+    image: docker.io/library/alpine:3.24.1@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+    command: sh -c 'sleep 60'
+networks:
+  default:
+    name: none
+    external: true

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
@@ -264,6 +264,9 @@ features:
           target: overlays/etc/NetworkManager/system-connections.d/wlan1-hotspot/63-ipv4-link-local.nmconnection
   windows-ncsi-active-probing:
     description: Prevent Windows from automatically disconnecting from hotspot without internet access
+    compose-files:
+      - deployment.compose.yml
+      - frontend.compose.yml
     requires:
       filesets:
         - description: Drop-in directory for hosts fragment files to generate the hosts file
@@ -271,7 +274,21 @@ features:
             - drop-in-assembly
           paths:
             - /etc/hosts.d
+      networks:
+        - description: Overlay network for Caddy to connect to upstream services
+          name: caddy-ingress-untrusted
+      services:
+        - tags: [caddy-docker-proxy]
+          port: 8000
+          protocol: http
     provides:
       file-exports:
         - description:
           target: overlays/etc/hosts.d/40-direct-windows-ncsi
+      services:
+        - description: Microsoft NCSI Active Probing bypasses
+          port: 8000
+          protocol: http
+          paths:
+            - /connecttest.txt
+            - /ncsi.txt

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
@@ -290,5 +290,7 @@ features:
           port: 8000
           protocol: http
           paths:
-            - /connecttest.txt
-            - /ncsi.txt
+            - www.msftconnecttest.com/connecttest.txt
+            - www.msftconnecttest.com/redirect
+            - www.msftncsi.com/ncsi.txt
+            - www.msftncsi.com/redirect

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
@@ -262,3 +262,16 @@ features:
       file-exports:
         - description: Drop-in NetworkManager connection fragment with enabelement of link-local IPv4 address
           target: overlays/etc/NetworkManager/system-connections.d/wlan1-hotspot/63-ipv4-link-local.nmconnection
+  windows-ncsi-active-probing:
+    description: Prevent Windows from automatically disconnecting from hotspot without internet access
+    requires:
+      filesets:
+        - description: Drop-in directory for hosts fragment files to generate the hosts file
+          tags:
+            - drop-in-assembly
+          paths:
+            - /etc/hosts.d
+    provides:
+      file-exports:
+        - description:
+          target: overlays/etc/hosts.d/40-direct-windows-ncsi

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
@@ -263,7 +263,7 @@ features:
         - description: Drop-in NetworkManager connection fragment with enabelement of link-local IPv4 address
           target: overlays/etc/NetworkManager/system-connections.d/wlan1-hotspot/63-ipv4-link-local.nmconnection
   windows-ncsi-active-probing:
-    description: Prevent Windows from automatically disconnecting from hotspot without internet access
+    description: Prevent Windows from automatically disconnecting from the hotspot if there's no internet access
     compose-files:
       - deployment.compose.yml
       - frontend.compose.yml
@@ -290,6 +290,6 @@ features:
           port: 8000
           protocol: http
           paths:
-            - /connecttest.txt
-            - /ncsi.txt
+            - //www.msftconnecttest.com/connecttest.txt
+            - //www.msftncsi.com/ncsi.txt
             - /redirect

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/forklift-package.yml
@@ -290,7 +290,6 @@ features:
           port: 8000
           protocol: http
           paths:
-            - www.msftconnecttest.com/connecttest.txt
-            - www.msftconnecttest.com/redirect
-            - www.msftncsi.com/ncsi.txt
-            - www.msftncsi.com/redirect
+            - /connecttest.txt
+            - /ncsi.txt
+            - /redirect

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/frontend.compose.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/frontend.compose.yml
@@ -3,19 +3,13 @@ services:
     networks:
       - caddy-ingress
     labels:
-      # For Windows 10+:
-      caddy_0: http://www.msftconnecttest.com
-      # To make Windows detect a captive portal:
-      caddy_0.redir_0: /connecttest.txt /
+      caddy: http://
+      # To make Windows 10 or newer detect a captive portal:
+      caddy.redir_0: /connecttest.txt /
+      # To make Windows 8.1 or below detect a captive portal:
+      caddy.redir_1: /ncsi.txt /
       # To make Windows redirect the captive portal to the landing page:
-      caddy_0.redir_2: /redirect /
-
-      # For older versions of Windows
-      caddy_1: http://www.msftncsi.com
-      # To make Windows detect a captive portal:
-      caddy_1.redir_1: /ncsi.txt /
-      # To make Windows redirect the captive portal to the landing page:
-      caddy_1.redir_2: /redirect /
+      caddy.redir_2: /redirect /
 
 networks:
   caddy-ingress:

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/frontend.compose.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/frontend.compose.yml
@@ -1,0 +1,12 @@
+services:
+  reverse-proxy-config:
+    networks:
+      - caddy-ingress
+    labels:
+      caddy: http://
+      caddy.redir_0: /connecttest.txt /
+      caddy.redir_1: /ncsi.txt /
+
+networks:
+  caddy-ingress:
+    external: true

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/frontend.compose.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/frontend.compose.yml
@@ -3,9 +3,19 @@ services:
     networks:
       - caddy-ingress
     labels:
-      caddy: http://
-      caddy.redir_0: /connecttest.txt /
-      caddy.redir_1: /ncsi.txt /
+      # For Windows 10+:
+      caddy_0: http://www.msftconnecttest.com
+      # To make Windows detect a captive portal:
+      caddy_0.redir_0: /connecttest.txt /
+      # To make Windows redirect the captive portal to the landing page:
+      caddy_0.redir_2: /redirect /
+
+      # For older versions of Windows
+      caddy_1: http://www.msftncsi.com
+      # To make Windows detect a captive portal:
+      caddy_1.redir_1: /ncsi.txt /
+      # To make Windows redirect the captive portal to the landing page:
+      caddy_1.redir_2: /redirect /
 
 networks:
   caddy-ingress:

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/frontend.compose.yml
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/frontend.compose.yml
@@ -3,13 +3,15 @@ services:
     networks:
       - caddy-ingress
     labels:
-      caddy: http://
+      # To make Windows redirect any captive portal page to the landing page:
+      caddy_0: http://
+      caddy_0.redir: /redirect /
       # To make Windows 10 or newer detect a captive portal:
-      caddy.redir_0: /connecttest.txt /
+      caddy_1: http://www.msftconnecttest.com
+      caddy_1.respond: /connecttest.txt "Microsoft Connect Test"
       # To make Windows 8.1 or below detect a captive portal:
-      caddy.redir_1: /ncsi.txt /
-      # To make Windows redirect the captive portal to the landing page:
-      caddy.redir_2: /redirect /
+      caddy_2: http://www.msftncsi.com
+      caddy_2.respond_1: /ncsi.txt "Microsoft NCSI"
 
 networks:
   caddy-ingress:

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/overlays/etc/hosts.d/40-direct-windows-ncsi
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/overlays/etc/hosts.d/40-direct-windows-ncsi
@@ -1,0 +1,19 @@
+192.168.3.1     www.msftconnecttest.com
+192.168.4.1     www.msftconnecttest.com
+192.168.5.1     www.msftconnecttest.com
+192.168.6.1     www.msftconnecttest.com
+192.168.7.1     www.msftconnecttest.com
+192.168.8.1     www.msftconnecttest.com
+192.168.3.1     dns.msftncsi.com
+192.168.4.1     dns.msftncsi.com
+192.168.5.1     dns.msftncsi.com
+192.168.6.1     dns.msftncsi.com
+192.168.7.1     dns.msftncsi.com
+192.168.8.1     dns.msftncsi.com
+192.168.3.1     www.msftncsi.com
+192.168.4.1     www.msftncsi.com
+192.168.5.1     www.msftncsi.com
+192.168.6.1     www.msftncsi.com
+192.168.7.1     www.msftncsi.com
+192.168.8.1     www.msftncsi.com
+

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/overlays/etc/hosts.d/40-direct-windows-ncsi
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/overlays/etc/hosts.d/40-direct-windows-ncsi
@@ -5,6 +5,11 @@
 192.168.7.1     www.msftconnecttest.com
 192.168.8.1     www.msftconnecttest.com
 131.107.255.255 dns.msftncsi.com
+192.168.4.1     dns.msftncsi.com
+192.168.5.1     dns.msftncsi.com
+192.168.6.1     dns.msftncsi.com
+192.168.7.1     dns.msftncsi.com
+192.168.8.1     dns.msftncsi.com
 192.168.3.1     www.msftncsi.com
 192.168.4.1     www.msftncsi.com
 192.168.5.1     www.msftncsi.com

--- a/deployments/networking/networkmanager/wifi-hotspot.pkg/overlays/etc/hosts.d/40-direct-windows-ncsi
+++ b/deployments/networking/networkmanager/wifi-hotspot.pkg/overlays/etc/hosts.d/40-direct-windows-ncsi
@@ -4,12 +4,7 @@
 192.168.6.1     www.msftconnecttest.com
 192.168.7.1     www.msftconnecttest.com
 192.168.8.1     www.msftconnecttest.com
-192.168.3.1     dns.msftncsi.com
-192.168.4.1     dns.msftncsi.com
-192.168.5.1     dns.msftncsi.com
-192.168.6.1     dns.msftncsi.com
-192.168.7.1     dns.msftncsi.com
-192.168.8.1     dns.msftncsi.com
+131.107.255.255 dns.msftncsi.com
 192.168.3.1     www.msftncsi.com
 192.168.4.1     www.msftncsi.com
 192.168.5.1     www.msftncsi.com


### PR DESCRIPTION
Windows devices automatically disconnect from Wi-Fi networks without internet access after ~1 minute, and there's no user-friendly way to change that behavior. This PR provides a workaround, so that Windows devices won't think that the Wi-Fi hotspot lacks internet access (even if it does lack internet access in reality).

This work is tracked on Notion at https://app.notion.com/p/Windows-devices-automatically-disconnect-from-the-Wi-Fi-hotspot-3754e612c78a8023bf09f83839af76e9?source=copy_link .